### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-19
+
 ### Added
 - **RNG accessors**: new public API for reproducible random draws
   - `myogen.get_random_generator()` — always returns the current global RNG (tracks the latest `set_random_seed` call)
@@ -21,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **RNG architecture** (internal refactor): the six internal modules and eight example scripts that previously did `from myogen import RANDOM_GENERATOR, SEED` at module scope now call the accessor at each site, eliminating the stale-reference bug where `set_random_seed` didn't reach downstream modules or seed-derived generators
-- **Per-cell seed derivation**: the three sites in `myogen/simulator/neuron/cells.py` that built a per-cell seed as `SEED + (class_id+1)*(global_id+1)` — a formula that collided on swapped factors, e.g. `(0, 5)` and `(1, 2)` both resolved to `+6` — now use `derive_subseed(class_id, global_id)` (collision-free with respect to label order, built on `numpy.random.SeedSequence`). The `motor_unit_sim.py` `KMeans` `random_state` uses the same helper. **Consequence**: for a given global seed, RNG output differs from earlier releases; byte-identical reproduction of pre-`Unreleased` outputs is not possible without matching code
+- **Per-cell seed derivation**: the three sites in `myogen/simulator/neuron/cells.py` that built a per-cell seed as `SEED + (class_id+1)*(global_id+1)` — a formula that collided on swapped factors, e.g. `(0, 5)` and `(1, 2)` both resolved to `+6` — now use `derive_subseed(class_id, global_id)` (collision-free with respect to label order, built on `numpy.random.SeedSequence`). The `motor_unit_sim.py` `KMeans` `random_state` uses the same helper. **Consequence**: for a given global seed, RNG output differs from earlier releases; byte-identical reproduction of pre-0.9.0 outputs is not possible without matching code
 - **Example figures**: bar graphs in `02_finetune/01_optimize_dd_for_target_firing_rate.py`, `02_finetune/02_compute_force_from_optimized_dd.py` and `03_papers/watanabe/01_compute_baseline_force.py` replaced with dumbbell / violin + box + jittered-scatter plots that show the underlying distribution (all points when n<10, violin + box when n≥10)
 - **NEURON version alignment**: `README.md`, `docs/source/README.md`, `docs/source/index.md`, and `setup.py` Windows-install messaging now reference NEURON **8.2.7** (matching the Linux/macOS pip pin in `pyproject.toml` and the CI workflow) with the correct installer filename (`py-39-310-311-312-313`)
 - **Docs build**: pinned `sphinx<9` in the `docs` dependency-group to work around a `sphinx-hoverxref` regression on Sphinx 9, and moved `[tool.pytest.ini_options]` in `pyproject.toml` so it no longer re-parents the `docs` dependency-group

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
   [![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://nsquaredlab.github.io/MyoGen/)
   [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-  [![Version](https://img.shields.io/badge/version-0.8.5-orange.svg)](https://github.com/NsquaredLab/MyoGen)
+  [![Version](https://img.shields.io/badge/version-0.9.0-orange.svg)](https://github.com/NsquaredLab/MyoGen)
 
   [Installation](https://nsquaredlab.github.io/MyoGen/#installation) •
   [Documentation](https://nsquaredlab.github.io/MyoGen/) •

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,7 +8,7 @@
 
   [![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://nsquaredlab.github.io/MyoGen/)
   [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-  [![Version](https://img.shields.io/badge/version-0.8.3-orange.svg)](https://github.com/NsquaredLab/MyoGen)
+  [![Version](https://img.shields.io/badge/version-0.9.0-orange.svg)](https://github.com/NsquaredLab/MyoGen)
 
   [Installation](https://nsquaredlab.github.io/MyoGen/#installation) •
   [Documentation](https://nsquaredlab.github.io/MyoGen/) •

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "MyoGen"
-version = "0.8.5"
+version = "0.9.0"
 description = "Modular and extensible neuromuscular simulation framework for generating physiologically grounded motor-unit activity, muscle force, and EMG signals (surface and intramuscular)"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Version bump to **0.9.0** alongside a final CHANGELOG tidy.

### Version bump rationale (minor)

- New public API: `myogen.get_random_generator()`, `myogen.get_random_seed()`, `myogen.derive_subseed(*labels)`.
- Two attributes deprecated (`myogen.RANDOM_GENERATOR`, `myogen.SEED`), still importable with a `DeprecationWarning`.
- Behavioural RNG-output change: `derive_subseed` replaces the pre-0.9.0 `SEED + (class_id+1)*(global_id+1)` formula. A given global seed now produces different random draws than in 0.8.5 and earlier — the new output is correct (seed propagation previously broke across modules) but not byte-identical.
- Additive: unified fiber-simulation pipeline, NaN guards in firing-rate statistics, optional `elephant` extra, NEURON version alignment to 8.2.7, figure distribution plots, new test suite, PR pytest CI.

### Changes in this PR

- `pyproject.toml`: `0.8.5` → `0.9.0`
- `CHANGELOG.md`: populated `Unreleased` section renamed to `[0.9.0] - 2026-04-19`; fresh empty `Unreleased` added above. Stale `pre-Unreleased outputs` reference rewritten as `pre-0.9.0 outputs`.
- `README.md` and `docs/source/index.md`: version badges bumped (README was pinned at 0.8.5; docs-site badge was even staler at 0.8.3).

After merge I'll tag `v0.9.0` on the merge commit.