### PR TITLE
fix: correct min_radial_dist unit mismatch in calc_sfaps

### DIFF
--- a/myogen/simulator/core/emg/intramuscular/motor_unit_sim.py
+++ b/myogen/simulator/core/emg/intramuscular/motor_unit_sim.py
@@ -255,7 +255,9 @@ class MotorUnitSim:
         electrode_normals : np.ndarray, optional
             Electrode normal vectors (not used for point electrodes)
         min_radial_dist : float, optional
-            Minimum radial distance for stability (default: mean diameter * 1000)
+            Minimum radial distance in mm to prevent singularity when a
+            fiber is extremely close to the electrode.  Defaults to the
+            mean fiber diameter (in mm).
         verbose : bool, default=True
             If True, display progress bars. Set to False to disable.
         """
@@ -265,8 +267,8 @@ class MotorUnitSim:
 
         if min_radial_dist is None:
             min_radial_dist = float(
-                np.mean(self.muscle_fiber_diameters__mm) * 1000
-            )  # Convert to micrometers
+                np.mean(self.muscle_fiber_diameters__mm)
+            )
 
         if self._neuromuscular_z_coordinates__mm is None:
             raise ValueError(


### PR DESCRIPTION
## Summary

The default `min_radial_dist` in `MotorUnitSim.calc_sfaps()` is computed as:

```python
min_radial_dist = float(np.mean(self.muscle_fiber_diameters__mm) * 1000)
```

With typical fiber diameters of ~0.05 mm, this yields a clamping threshold of **~52.5 mm**. Since `radial_distance` (fiber-to-electrode, line 349) is in **mm** and ranges from 0.03–8.5 mm, every fiber is clamped to the same value, making SFAPs **spatially invariant** to electrode XY displacement.

## Changes

- **Remove `* 1000` multiplier** — the clamping threshold now equals the mean fiber diameter (~0.05 mm), keeping consistent mm units.
- **Update docstring** — clarify that `min_radial_dist` is in mm and serves as a singularity guard.

## Impact

After this fix, `calc_sfaps()` correctly produces distance-dependent SFAP amplitudes. All existing tests pass (`39 passed, 2 skipped`).
