### PR TITLE
Calibratable colored iEMG noise model

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -20,8 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-latest = arm64, macos-13 = x86_64 (covers Intel Macs)
-        os: [ubuntu-latest, macos-latest, macos-13]
+        # macos-latest = arm64 (Apple Silicon). Intel (x86_64) macos-13
+        # runner dropped — GitHub is retiring it.
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -117,7 +118,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]  # Match build_wheels matrix
+        os: [ubuntu-latest, macos-latest]  # Match build_wheels matrix
         python-version: ["3.12"]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,9 @@ docs/serve_docs.sh
 
 # Git worktrees
 .worktrees/
+
+# macOS
+.DS_Store
+
+# Local scratch notes (kept in nexus, not the repo)
+notes/

--- a/examples/01_basic/09_simulate_intramuscular_emg.py
+++ b/examples/01_basic/09_simulate_intramuscular_emg.py
@@ -87,7 +87,12 @@ electrode = simulator.IntramuscularElectrodeArray(
 # Create the **intramuscular EMG simulator** with the muscle model and electrode.
 # All simulation parameters now use quantities for type safety and unit validation.
 
-MUs_to_simulate = [0, 25, 50, 90]
+# Simulate ~30 MUs sampled across the full recruitment range so the
+# composite iEMG sums enough MUAPs to look like a real recording, while
+# still keeping the MUAP computation reasonable. A small ``MUs_to_plot``
+# subset drives the per-MU MUAP figure below.
+MUs_to_simulate = list(range(0, 100, 3))  # 0, 3, 6, ..., 99 -> 34 MUs
+MUs_to_plot = [0, 25, 50, 90]
 
 print("Initializing iEMG simulator...")
 iemg_sim = simulator.IntramuscularEMG(
@@ -104,9 +109,9 @@ iemg_sim = simulator.IntramuscularEMG(
 print("Computing motor unit action potentials...")
 muaps__Block = iemg_sim.simulate_muaps(n_jobs=2)  # Use 2 parallel jobs
 
-# Display MUAP amplitudes for the selected MUs
+# Display MUAP amplitudes for the plotted MUs
 print("\n=== MUAP Amplitudes ===")
-for mu_idx in MUs_to_simulate:
+for mu_idx in MUs_to_plot:
     segment = muaps__Block.segments[mu_idx]
     if segment.name != "MUAP_None":
         signal = segment.analogsignals[0].magnitude
@@ -123,9 +128,9 @@ joblib.dump(iemg_sim, "./results/iemg_simulator.pkl")
 # Display the **MUAP waveforms** for the three selected motor units to
 # demonstrate how motor unit size affects MUAP amplitude and shape.
 
-fig, axes = plt.subplots(len(MUs_to_simulate), 1, figsize=(12, 8), sharex=True)
+fig, axes = plt.subplots(len(MUs_to_plot), 1, figsize=(12, 8), sharex=True)
 
-for plot_idx, mu_idx in enumerate(MUs_to_simulate):
+for plot_idx, mu_idx in enumerate(MUs_to_plot):
     segment = muaps__Block.segments[mu_idx]
     if segment.name != "MUAP_None":
         muap_signal = segment.analogsignals[0][:, 0]  # First electrode channel

--- a/examples/01_basic/14_calibrate_noise_from_real.py
+++ b/examples/01_basic/14_calibrate_noise_from_real.py
@@ -1,0 +1,500 @@
+"""
+Calibrate the Noise Profile from a Real Recording
+=================================================
+
+This example takes a real iEMG recording, derives a device-matched
+noise profile with :func:`myogen.utils.calibrate_realistic_noise_profile`,
+then generates simulated noise with the derived parameters and overlays
+the real and simulated PSDs in a single figure so the match is
+visually verifiable.
+
+This is the same calibration pipeline used to derive MyoGen's default
+``quattrocento`` profile:
+
+1. Notch out powerline harmonics (50/100/150/200/250 Hz for EU).
+2. Extract pure-noise residuals from rest segments
+   (or high-frequency content above 2 kHz as a fallback).
+3. Fit ``noise_floor_uv``, ``spectral_slope``, ``peak_hz``,
+   ``excess_kurtosis``, ``powerline_amplitude``, and per-harmonic ratios.
+
+The derived dict can be unpacked directly into the simulator via::
+
+    iemg.add_noise(snr__dB=20.0, noise_type="realistic", **profile)
+
+.. note::
+    This example expects a MAT v7.3 file with an ``EMGSIGNAL`` struct
+    (``data`` shape ``(n_channels, n_samples)``, ``rate`` in Hz) and a
+    ``target_signal`` (drive envelope, ``0`` = rest). Adjust the
+    loader for other formats — only the µV array + sample rate
+    + optional rest mask actually feed the calibration.
+"""
+# sphinx_gallery_thumbnail_number = -1
+
+# %%
+
+##############################################################################
+# Import Libraries
+# ----------------
+
+import os
+from pathlib import Path
+
+import h5py
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+import numpy as np
+import seaborn as sns
+from matplotlib.ticker import ScalarFormatter
+from scipy import signal as sig
+from scipy.stats import kurtosis
+
+from myogen import set_random_seed
+from myogen.utils import (
+    calibrate_realistic_noise_profile,
+    generate_realistic_noise,
+    tune_noise_profile_with_optuna,
+)
+
+# Clean, Nature-style theme (matches the parameter-sweep figure).
+plt.rcParams.update({
+    "figure.facecolor": "white",
+    "axes.facecolor": "white",
+    "savefig.facecolor": "white",
+    "font.family": "sans-serif",
+    "font.sans-serif": ["Arial", "Helvetica", "DejaVu Sans"],
+    "font.size": 4.5,
+    "axes.titlesize": 5.5,
+    "axes.labelsize": 4.5,
+    "xtick.labelsize": 4.0,
+    "ytick.labelsize": 4.0,
+    "legend.fontsize": 4.0,
+    "axes.linewidth": 0.5,
+    "axes.edgecolor": "#222222",
+    "axes.grid": False,
+    "axes.spines.top": False,
+    "axes.spines.right": False,
+    "lines.linewidth": 1.0,
+    "lines.solid_capstyle": "round",
+    "lines.solid_joinstyle": "round",
+    "xtick.direction": "out",
+    "ytick.direction": "out",
+    "xtick.major.width": 0.5,
+    "ytick.major.width": 0.5,
+    "xtick.major.size": 2.0,
+    "ytick.major.size": 2.0,
+    "legend.frameon": True,
+    "legend.framealpha": 0.9,
+    "legend.edgecolor": "#cccccc",
+    "svg.fonttype": "none",
+    # Keep every sample in the saved vector — no silent path thinning, so the
+    # MUAPs stay zoomable in Affinity/Illustrator.
+    "path.simplify": False,
+})
+
+# Resolve relative to this file so the example saves into
+# examples/01_basic/results/ regardless of the current working
+# directory at run time.
+save_path = (Path(__file__).resolve().parent / "results")
+save_path.mkdir(exist_ok=True, parents=True)
+
+##############################################################################
+# Load the Real Recording
+# -----------------------
+#
+# Point this at one of your own ramp recordings. Override the path without
+# editing the file via the ``MYOGEN_IEMG_MAT`` environment variable; the
+# calibration only uses (signal in µV, sampling rate, rest mask).
+DEFAULT_MAT = Path.home() / "Downloads" / "Ramps" / "30MVC_pos_iEMG.mat"
+REAL_MAT = Path(os.environ.get("MYOGEN_IEMG_MAT", DEFAULT_MAT))
+TARGET_MUSCLE = "VL"  # one of "VM", "RF", "VL"
+
+if REAL_MAT.exists():
+    with h5py.File(REAL_MAT, "r") as f:
+        fs_hz = float(f["EMGSIGNAL/rate"][()].squeeze())
+        emg_mv = f["EMGSIGNAL/data"][:]  # (n_channels, n_samples), mV
+        target = f["target_signal"][:].squeeze()  # commanded drive
+
+    # 3 channels per muscle: VM (1-3), RF (4-6), VL (7-9), 1-indexed in MATLAB.
+    muscle_channel_map = {"VM": (0, 1, 2), "RF": (3, 4, 5), "VL": (6, 7, 8)}
+    ch_indices = muscle_channel_map[TARGET_MUSCLE]
+
+    # Convert mV → µV, transpose to (n_samples, n_channels) for the calibrator.
+    real_uv = emg_mv[list(ch_indices), :].T * 1000.0
+    rest_mask = target < 0.01
+    source = f"{REAL_MAT.name} ({TARGET_MUSCLE}, channels {ch_indices})"
+else:
+    # No recording found — synthesise a short stand-in so the example runs
+    # anywhere: three channels of the realistic device noise the model
+    # produces, plus a brief higher-amplitude "contraction" in the middle so
+    # the rest mask and the panel-a trace have structure. Point
+    # MYOGEN_IEMG_MAT at a real .mat to calibrate against your own hardware.
+    fs_hz = 10240.0
+    n_demo = int(60 * fs_hz)
+    demo_rng = np.random.default_rng(0)
+    real_uv = np.stack(
+        [
+            generate_realistic_noise(n_demo, fs_hz, 4.0, rng=np.random.default_rng(ch))
+            for ch in range(3)
+        ],
+        axis=1,
+    )
+    rest_mask = np.ones(n_demo, dtype=bool)
+    burst = slice(int(0.40 * n_demo), int(0.60 * n_demo))
+    real_uv[burst] += demo_rng.normal(0.0, 40.0, size=(burst.stop - burst.start, 3))
+    rest_mask[burst] = False
+    source = "synthetic demo (set MYOGEN_IEMG_MAT for real calibration)"
+
+print(f"Loaded {source}")
+print(f"  fs           : {fs_hz:.0f} Hz")
+print(f"  duration     : {real_uv.shape[0] / fs_hz:.0f} s")
+print(f"  rest fraction: {rest_mask.mean() * 100:.1f}%")
+
+##############################################################################
+# Calibrate the Noise Profile
+# ---------------------------
+#
+# The calibration pipeline in a single call — derives the same parameter set
+# the simulator's ``noise_type="realistic"`` mode consumes.
+
+profile = calibrate_realistic_noise_profile(
+    real_uv, fs_hz, rest_mask=rest_mask, powerline_hz=50.0
+)
+
+print("\nDerived profile:")
+for key, value in profile.items():
+    if isinstance(value, list):
+        print(f"  {key:30s} {[round(x, 3) for x in value]}")
+    elif isinstance(value, float):
+        print(f"  {key:30s} {value:.4f}")
+    else:
+        print(f"  {key:30s} {value}")
+
+##############################################################################
+# Refine the Profile with Optuna
+# ------------------------------
+#
+# The closed-form profile fits the moments but leaves residual shape
+# mismatch (e.g., low-frequency rolloff curvature). Optuna runs a TPE
+# search around the closed-form solution, minimising the L1 log-PSD
+# distance — a few seconds of compute typically halves the residual.
+
+print("\nRunning Optuna refinement (this takes a few seconds)...")
+tuned_profile = tune_noise_profile_with_optuna(
+    real_uv,
+    fs_hz,
+    profile,
+    rest_mask=rest_mask,
+    n_trials=120,
+)
+
+print("\nTuned profile:")
+for key, value in tuned_profile.items():
+    if isinstance(value, list):
+        print(f"  {key:30s} {[round(x, 3) for x in value]}")
+    elif isinstance(value, float):
+        print(f"  {key:30s} {value:.4f}")
+    else:
+        print(f"  {key:30s} {value}")
+
+##############################################################################
+# Generate Simulated Noise from Both Profiles
+# -------------------------------------------
+#
+# Match the duration of the rest segments used for calibration so the
+# Welch averages are over comparable lengths.
+
+
+def _make_sim_noise(prof: dict, n: int) -> np.ndarray:
+    return generate_realistic_noise(
+        n,
+        fs_hz,
+        noise_rms=prof["noise_floor_uv"],
+        spectral_slope=prof["spectral_slope"],
+        excess_kurtosis=prof["excess_kurtosis"],
+        powerline_hz=prof["powerline_hz"],
+        powerline_amplitude=prof["powerline_amplitude"],
+        powerline_harmonic_ratios=prof["powerline_harmonic_ratios"],
+        peak_hz=prof["peak_hz"],
+        analog_hpf_hz=prof["analog_hpf_hz"],
+    )
+
+
+set_random_seed(0)
+n_rest_samples = int(rest_mask.sum())
+sim_noise = _make_sim_noise(profile, n_rest_samples)
+set_random_seed(0)
+sim_noise_tuned = _make_sim_noise(tuned_profile, n_rest_samples)
+
+print(f"\nSimulated noise RMS (closed-form): {np.sqrt(np.mean(sim_noise ** 2)):.3f} µV")
+print(f"Simulated noise RMS (tuned)      : {np.sqrt(np.mean(sim_noise_tuned ** 2)):.3f} µV")
+print(f"Real (rest-mask) RMS             : {np.sqrt(np.mean(real_uv[rest_mask] ** 2)):.3f} µV (averaged across channels)")
+
+##############################################################################
+# PSD Overlay — Real vs Simulated
+# -------------------------------
+#
+# Welch PSDs on log-frequency, dB axes. Real (averaged across the
+# muscle's channels) in solid grey; simulated in colour. A close match
+# means the profile reproduces the device + environment noise.
+
+nperseg = min(8192, n_rest_samples)
+noverlap = int(nperseg * 0.75)
+
+# Per-channel real PSD on rest, then median across channels.
+real_psd_stack = []
+for ch in range(real_uv.shape[1]):
+    f_real, psd_ch = sig.welch(
+        real_uv[rest_mask, ch],
+        fs=fs_hz,
+        nperseg=nperseg,
+        noverlap=noverlap,
+        average="median",
+    )
+    real_psd_stack.append(psd_ch)
+real_psd = np.median(np.stack(real_psd_stack, axis=0), axis=0)
+
+f_sim, sim_psd = sig.welch(
+    sim_noise,
+    fs=fs_hz,
+    nperseg=nperseg,
+    noverlap=noverlap,
+    average="median",
+)
+f_sim_t, sim_psd_tuned = sig.welch(
+    sim_noise_tuned,
+    fs=fs_hz,
+    nperseg=nperseg,
+    noverlap=noverlap,
+    average="median",
+)
+
+real_db = 10.0 * np.log10(np.maximum(real_psd, 1e-30))
+sim_db = 10.0 * np.log10(np.maximum(sim_psd, 1e-30))
+sim_db_tuned = 10.0 * np.log10(np.maximum(sim_psd_tuned, 1e-30))
+
+REAL_C = "#111111"        # real recording
+CLOSED_C = "#9aa0a6"      # closed-form profile
+TUNED_C = "#d62728"       # Optuna-tuned profile
+
+# Per-knob accent colours — identical to the parameter-sweep figure so the
+# two figures read as a matched pair.
+KNOB_COLOR = {
+    "noise_floor_uv": "#1f77b4",
+    "spectral_slope": "#ff7f0e",
+    "peak_hz": "#2ca02c",
+    "powerline_amplitude": "#7e3ca2",
+    "analog_hpf_hz": "#d62728",
+    "excess_kurtosis": "#7f7f7f",
+}
+
+
+def _panel_letter(ax, letter, *, dx=-0.02):
+    ax.text(dx, 1.04, letter, transform=ax.transAxes, fontsize=7,
+            fontweight="bold", color="#111111", ha="right", va="bottom")
+
+
+# Cleanest channel (lowest kurtosis) for the example traces.
+_dm_all = real_uv[rest_mask] - real_uv[rest_mask].mean(axis=0)
+clean_ch = int(np.argmin([kurtosis(_dm_all[:, c]) for c in range(_dm_all.shape[1])]))
+
+fig = plt.figure(figsize=(7.18, 3.2))
+outer = gridspec.GridSpec(2, 2, figure=fig, height_ratios=[0.7, 2.0],
+                          width_ratios=[1.55, 1.0], hspace=0.6, wspace=0.42)
+ax_act = fig.add_subplot(outer[0, :])                 # activation segment (motor units), full width
+left = outer[1, 0].subgridspec(2, 1, height_ratios=[3.0, 1.0], hspace=0.10)
+ax_psd = fig.add_subplot(left[0])
+ax_res = fig.add_subplot(left[1], sharex=ax_psd)
+ax_par = fig.add_subplot(outer[1, 1])
+
+##############################################################################
+# Panel a — PSD match (real vs closed-form vs Optuna-tuned) + residual
+# --------------------------------------------------------------------
+
+for f_line in (50.0, 100.0, 150.0, 200.0, 250.0):
+    ax_psd.axvline(f_line, color="#dddddd", linewidth=0.5, zorder=0)
+ax_psd.semilogx(f_real, real_db, color=REAL_C, linewidth=1.3, label="Real (rest)")
+ax_psd.semilogx(f_sim, sim_db, color=CLOSED_C, linewidth=1.0, label="Closed-form")
+ax_psd.semilogx(f_sim_t, sim_db_tuned, color=TUNED_C, linewidth=1.1, label="Optuna-tuned")
+ax_psd.set_xlim(5.0, fs_hz / 2.0)
+ax_psd.set_ylabel("PSD (dB)")
+ax_psd.tick_params(labelbottom=False)
+ax_psd.grid(True, axis="y", alpha=0.22, linewidth=0.5)
+ax_psd.legend(loc="upper right", facecolor="white", edgecolor="#cccccc",
+              framealpha=0.95, handlelength=1.6, borderpad=0.4)
+ax_psd.set_title(f"Calibrated noise model vs real device ({TARGET_MUSCLE})",
+                 loc="left", fontweight="bold", color="#111111", pad=4)
+_panel_letter(ax_psd, "b", dx=-0.08)
+
+# Residual strip: simulated − real (closer to 0 is better).
+ax_res.axhspan(-3, 3, color="#eeeeee", zorder=0)
+ax_res.axhline(0, color="#888888", linewidth=0.6)
+ax_res.semilogx(f_real, sim_db - real_db, color=CLOSED_C, linewidth=0.9)
+ax_res.semilogx(f_real, sim_db_tuned - real_db, color=TUNED_C, linewidth=1.0)
+ax_res.set_xlim(5.0, fs_hz / 2.0)
+ax_res.set_xticks([10, 50, 100, 500, 1000, 5000])
+ax_res.get_xaxis().set_major_formatter(ScalarFormatter())
+ax_res.minorticks_off()
+ax_res.set_ylim(-8, 8)
+ax_res.set_xlabel("Frequency (Hz)")
+ax_res.set_ylabel("Δ (dB)")
+
+##############################################################################
+# Panel b — how much Optuna moved each knob (% change from the quick fit)
+# -----------------------------------------------------------------------
+#
+# Each bar shows where Optuna settled *within that knob's search range*,
+# normalised to 0 % (lower bound) – 100 % (upper bound). This is directly
+# comparable across knobs and immune to the near-zero-baseline blow-up that
+# a (tuned − quick)/quick ratio suffers. The closed-form starting point is
+# marked with a tick so the move is visible. Colour matches the sweep tiles.
+#
+# Bounds replicate tune_noise_profile_with_optuna's _objective exactly
+# (search ranges are defined relative to the closed-form `profile`).
+
+# excess_kurtosis is intentionally omitted: it's a time-domain 4th-moment
+# property the log-PSD objective can't constrain, so its tuned value is
+# meaningless here. Only knobs the spectral fit actually moves.
+_NYQ = fs_hz / 2.0
+PARAMS = [
+    ("noise_floor_uv", "Noise floor",
+     lambda i: (max(i * 0.5, 0.1), i * 2.0)),
+    ("spectral_slope", "Spectral slope",
+     lambda i: (i - 0.8, i + 0.8)),
+    ("peak_hz", "Mid-band peak",
+     lambda i: (max(i * 0.5, 100.0), min(i * 2.0, _NYQ * 0.9))),
+    ("powerline_amplitude", "Powerline amp",
+     lambda i: (max(i * 0.3, 0.0), i * 3.0 + 0.05)),
+    ("analog_hpf_hz", "Analog HPF",
+     lambda i: (max(i * 0.3, 1.0), i * 3.0)),
+]
+
+# Closed-form sits at 0 (centre). The bar runs toward whichever bound
+# Optuna moved to, normalised so the lower bound = −100 % and the upper
+# bound = +100 %. Each side is scaled independently (the search ranges are
+# asymmetric about the closed-form value), so 0 always means "no change"
+# and ±100 % always means "pinned to a search bound" — comparable across rows.
+for row, (key, label, bounds) in enumerate(PARAMS):
+    y = len(PARAMS) - 1 - row
+    c = KNOB_COLOR[key]
+    q, t = profile[key], tuned_profile[key]
+    lo, hi = bounds(q)
+    if t >= q:
+        frac = (t - q) / (hi - q) * 100.0 if (hi - q) > 1e-12 else 0.0
+    else:
+        frac = (t - q) / (q - lo) * 100.0 if (q - lo) > 1e-12 else 0.0
+    frac = float(np.clip(frac, -100.0, 100.0))
+    ax_par.barh(y, frac, height=0.55, color=c, zorder=2)
+    off = 4 if frac >= 0 else -4
+    ax_par.text(frac + off, y, f"{frac:+.0f}%", va="center",
+                ha="left" if frac >= 0 else "right",
+                fontsize=4.0, color=c, fontweight="bold")
+
+# closed-form reference line down the middle
+ax_par.axvline(0, color="#111111", linewidth=0.9, zorder=3)
+
+ax_par.set_ylim(-0.6, len(PARAMS) - 0.4)
+ax_par.set_yticks(range(len(PARAMS)))
+ax_par.set_yticklabels([label for _, label, _ in PARAMS][::-1], fontsize=4.0)
+ax_par.set_xlim(-130, 130)
+ax_par.set_xticks([-100, 0, 100])
+ax_par.set_xticklabels(["−100%", "0", "+100%"])
+ax_par.set_xlabel("Move within search range  (0 = closed-form, ±100 % = bounds)")
+ax_par.tick_params(length=2)
+ax_par.set_title("How far Optuna moved each knob",
+                 loc="left", fontweight="bold", color="#111111", pad=4, fontsize=5.5)
+ax_par.grid(True, axis="x", alpha=0.18, linewidth=0.5)
+_panel_letter(ax_par, "c", dx=-0.32)
+
+##############################################################################
+# Panel a — the real recording in full, with a zoom on the rest noise
+# ------------------------------------------------------------------
+#
+# The whole signal (cleanest channel) shows the contraction towering over
+# the rest periods (shaded) — signal ≫ noise. The boxed rest window is
+# zoomed on the right to reveal the device-noise texture we calibrate to.
+
+_sig = real_uv[:, clean_ch].astype(float)
+_sig = _sig - _sig.mean()
+
+# One full activation block (motor units firing) next to one full rest
+# block (device noise). Plotted at full sample rate; the dense lines are
+# rasterised so every sample is rendered faithfully without a giant vector
+# path. Both panels share the same µV scale so the signal≫noise gap is honest.
+def _runs_of(mask):
+    e = np.diff(np.concatenate([[0], mask.astype(int), [0]]))
+    return list(zip(np.where(e == 1)[0], np.where(e == -1)[0]))
+
+
+def _longest(runs):
+    return max(runs, key=lambda se: se[1] - se[0])
+
+
+SEG_S = 45.0                                           # window length per panel
+_sn = int(SEG_S * fs_hz)
+
+
+def _center_window(run):
+    s, e = run
+    c = (s + e) // 2
+    a = int(np.clip(c - _sn // 2, 0, _sig.size - _sn))
+    return a, a + _sn
+
+
+_a0, _a1 = _center_window(_longest(_runs_of(~rest_mask)))   # 60 s around a contraction
+_at = np.arange(_a1 - _a0) / fs_hz                     # s
+_ymax = 1.05 * np.max(np.abs(_sig[_a0:_a1]))
+
+# Activation — motor units tower over the noise floor, full width.
+ax_act.plot(_at, _sig[_a0:_a1], color=REAL_C, linewidth=0.15, rasterized=True)
+ax_act.set_xlim(0, _at[-1])
+ax_act.set_ylim(-_ymax, _ymax)
+ax_act.set_xlabel("Time (s)")
+ax_act.set_ylabel("µV")
+ax_act.set_title(f"Real iEMG — motor units during contraction  (t≈{_a0 / fs_hz:.0f} s, {_at[-1]:.0f} s window)",
+                 loc="left", fontweight="bold", color="#111111", pad=4, fontsize=5.5)
+_panel_letter(ax_act, "a", dx=-0.08)
+
+sns.despine(ax=ax_act, offset=2, trim=False)
+sns.despine(ax=ax_psd, offset=2, trim=False)
+sns.despine(ax=ax_res, offset=2, trim=False)
+sns.despine(ax=ax_par, offset=2, trim=False, left=False)
+
+plt.tight_layout()
+# dpi=600 sets the resolution of the rasterised iEMG traces inside the
+# otherwise-vector SVG/PDF (text, axes, panels b/c stay vector).
+fig.savefig(save_path / "noise_calibration_overlay.png", dpi=600, transparent=True)
+fig.savefig(save_path / "noise_calibration_overlay.svg", dpi=600, transparent=True)
+fig.savefig(save_path / "noise_calibration_overlay.pdf", dpi=600, transparent=True)
+plt.show()
+
+##############################################################################
+# How Close is the Match?
+# -----------------------
+#
+# We summarise the agreement in three bands so it's a single-number
+# read on how well the simulator reproduces the real spectrum.
+
+bands = [("20-100 Hz", 20.0, 100.0), ("100-500 Hz", 100.0, 500.0), ("500-2000 Hz", 500.0, 2000.0)]
+
+
+def _band_power(freqs: np.ndarray, psd: np.ndarray, lo: float, hi: float) -> float:
+    mask = (freqs >= lo) & (freqs <= hi)
+    if not np.any(mask):
+        return 0.0
+    return float(np.sum(psd[mask]) * (freqs[1] - freqs[0]))
+
+
+print("\nBand-power match (dB difference; |Δ| < 3 dB is a tight match):")
+print(f"  {'band':<14}{'real (dB)':>12}{'sim (dB)':>12}{'Δ closed':>11}{'Δ tuned':>11}")
+for label, lo, hi in bands:
+    p_real = _band_power(f_real, real_psd, lo, hi)
+    p_sim = _band_power(f_sim, sim_psd, lo, hi)
+    p_sim_t = _band_power(f_sim_t, sim_psd_tuned, lo, hi)
+    db_real = 10.0 * np.log10(max(p_real, 1e-30))
+    db_sim = 10.0 * np.log10(max(p_sim, 1e-30))
+    db_sim_t = 10.0 * np.log10(max(p_sim_t, 1e-30))
+    print(
+        f"  {label:<14}{db_real:>12.2f}{db_sim_t:>12.2f}"
+        f"{db_sim - db_real:>11.2f}{db_sim_t - db_real:>11.2f}"
+    )
+print(f"\nOptuna final log-PSD L1 loss: {tuned_profile['_optuna_loss']:.4f}")

--- a/examples/01_basic/15_noise_parameter_sweep.py
+++ b/examples/01_basic/15_noise_parameter_sweep.py
@@ -1,0 +1,746 @@
+"""
+Noise Parameter Sweep — overview + dense colour-mapped tiles
+============================================================
+
+Each tunable knob of the realistic noise model acts on a specific part
+of the spectrum. This example lays the knobs out as a **two-row figure**:
+
+* a top **overview PSD** (baseline noise in black) annotated with
+  coloured markers showing which frequency region each knob touches;
+* a **2x3 grid of zoom tiles** below, each focused on its knob's active
+  region. Every tile sweeps its knob through many values, drawn as a
+  dense family of curves shaded by a **white → knob-colour colormap**
+  (with a matching colourbar), plus the baseline as a black reference —
+  the same treatment used for the motor-neuron property sweeps.
+
+The same colour is reused per knob — overview highlight, zoom-tile title,
+the tile's left spine, and the colormap — so the link between "where it
+acts" and "what it does" is unambiguous.
+"""
+# sphinx_gallery_thumbnail_number = -1
+
+# %%
+
+##############################################################################
+# Imports and publication style
+# ------------------------------
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import matplotlib.gridspec as gridspec
+import numpy as np
+import seaborn as sns
+from matplotlib.ticker import FuncFormatter, NullFormatter, ScalarFormatter
+from scipy import signal as sig
+from scipy.ndimage import gaussian_filter1d
+
+from myogen import set_random_seed
+from myogen.utils import generate_realistic_noise
+
+# Clean, Nature-style theme: white canvas, thin black spines, sans-serif,
+# no heavy grid.
+plt.rcParams.update(
+    {
+        "figure.facecolor": "white",
+        "axes.facecolor": "white",
+        "savefig.facecolor": "white",
+        "font.family": "sans-serif",
+        "font.sans-serif": ["Arial", "Helvetica", "DejaVu Sans"],
+        "font.size": 4.5,
+        "axes.titlesize": 5.5,
+        "axes.labelsize": 4.5,
+        "xtick.labelsize": 4.0,
+        "ytick.labelsize": 4.0,
+        "legend.fontsize": 4.0,
+        "axes.linewidth": 0.5,
+        "axes.edgecolor": "#222222",
+        "axes.grid": False,
+        "axes.spines.top": False,
+        "axes.spines.right": False,
+        "lines.linewidth": 0.6,
+        "lines.solid_capstyle": "round",
+        "lines.solid_joinstyle": "round",
+        "xtick.direction": "out",
+        "ytick.direction": "out",
+        "xtick.major.width": 0.5,
+        "ytick.major.width": 0.5,
+        "xtick.major.size": 2.0,
+        "ytick.major.size": 2.0,
+        "legend.frameon": True,
+        "legend.framealpha": 0.9,
+        "legend.edgecolor": "#cccccc",
+        "svg.fonttype": "none",
+    }
+)
+
+save_path = Path(__file__).resolve().parent / "results"
+save_path.mkdir(exist_ok=True, parents=True)
+
+##############################################################################
+# Baseline and sweep specification
+# --------------------------------
+
+FS_HZ = 10240.0
+DURATION_S = 20.0
+N_SAMPLES = int(FS_HZ * DURATION_S)
+
+# How many curves per knob — dense enough to read as a continuous gradient.
+N_SWEEP = 15
+# Sweep-curve line width.
+CURVE_LW = 0.8
+# Gaussian smoothing (in PSD bins) for broadband tiles, so the noisy curves
+# become clean nested lines that separate clearly. Spike tiles stay raw.
+SMOOTH_SIGMA = 4.0
+
+BASELINE = dict(
+    noise_floor_uv=4.0,
+    spectral_slope=-0.5,
+    excess_kurtosis=3.0,
+    powerline_hz=50.0,
+    powerline_amplitude=0.1,
+    powerline_harmonic_ratios=None,
+    peak_hz=1000.0,
+    analog_hpf_hz=10.0,
+)
+
+# Per-knob: display label, colour, colourbar unit label, tick formatter,
+# the swept range as (lo, hi, scale) — "log" or "linear" — for both the
+# sweep values and the colour normalisation, the zoom x-range (Hz, None
+# for full band), the x-axis scale, and an indicator string describing the
+# region kind (used to draw the matching highlight on the overview).
+# Order matches the left-to-right order of the callouts in panel a
+# (by frequency): HPF → powerline → noise floor → mid-band peak → HF slope.
+SWEEPS = [
+    {
+        "knob": "analog_hpf_hz",
+        "label": "Analog high-pass corner (Hz)",
+        "color": "#d62728",  # distinct red — set apart from the purple powerline pair
+        "low_color": "#7f7f7f",  # gray (low) ↔ red (high accent)
+        "curve_lw": 0.8,
+        "cbar_label": "Hz",
+        "fmt": "{:.0f}",
+        "sweep": (1.0, 100.0, "log"),
+        "zoom_xlim": (2.0, 200.0),
+        "xscale": "log",
+        "region_kind": "axvspan_lowfreq",  # translucent band 2-30 Hz
+    },
+    {
+        "knob": "powerline_amplitude",
+        "label": "Powerline amplitude (× broadband)",
+        "color": "#7e3ca2",  # deep purple — both powerline knobs share this family
+        "low_color": "#17becf",  # teal (low) ↔ purple (high accent)
+        "smooth": True,
+        "smooth_sigma": 1.5,  # gentler than the broadband tiles (keeps harmonic peaks sharp)
+        "cbar_label": "frac",
+        "fmt": "{:g}",
+        # Plot each curve ÷ the baseline PSD on a log y-axis. The shared
+        # broadband floor cancels to a flat 1.0; only the powerline harmonics
+        # deviate — up for higher amplitude (purple), down for lower (green) —
+        # so the small-amplitude effect is no longer crushed by the floor.
+        "relative": True,
+        # Stack vertically (above 0.1 on top, below 0.1 on bottom) with
+        # independent y, so the small green deviations get their own row.
+        "split": "value",
+        "split_dir": "v",
+        # Multiplicative knob → log colour scale. Low end is 0.03 (not lower):
+        # below that a 50 Hz line sits under the broadband floor and adds
+        # nothing visible, so the low (green) curves would collapse onto it.
+        "sweep": (0.03, 1.0, "log"),
+        "zoom_xlim": (30.0, 300.0),
+        "xscale": "log",
+        "region_kind": "line_comb",  # vertical lines at 50/100/150
+    },
+    {
+        "knob": "powerline_hz",
+        "label": "Powerline fundamental (Hz)",
+        "color": "#7e3ca2",  # same purple as powerline_amplitude — matched powerline pair
+        "low_color": "#17becf",  # teal (low) ↔ purple (high accent)
+        "cbar_label": "Hz",
+        "fmt": "{:.0f}",
+        "sweep": (40.0, 60.0, "linear"),  # spike sweeps across the mains band, baseline 50 centred
+        # Rendered as TWO sub-panels (below / above 50 Hz) so the negative and
+        # positive shifts don't tangle together — handled in its own block.
+        "split": "freq",
+        "n_sweep": 20,  # per sub-panel (0.5 Hz spacing)
+        "curve_lw": 0.8,
+        # Narrow 40–60 Hz window needs a fine FFT to resolve individual Hz
+        # (default 2.5 Hz bins would merge adjacent fundamentals).
+        "nperseg": 20480,
+        "zoom_xlim": (40.0, 60.0),
+        "xscale": "linear",
+        "region_kind": "line_shift_arrow",  # 50 → 60 Hz arrow
+    },
+    {
+        "knob": "noise_floor_uv",
+        "label": "Noise floor (µV RMS)",
+        "color": "#1f77b4",
+        "low_color": "#d62728",  # red (low) ↔ blue (high accent)
+        "curve_lw": 0.8,
+        "cbar_label": "µV RMS",
+        "fmt": "{:.0f}",
+        "sweep": (1.0, 32.0, "log"),
+        "zoom_xlim": None,  # full band
+        "xscale": "log",
+        "region_kind": "rms_arrow",  # vertical double-arrow on the right
+    },
+    {
+        "knob": "peak_hz",
+        "label": "Mid-band peak frequency (Hz)",
+        "color": "#2ca02c",
+        "low_color": "#8c564b",  # brown (low) ↔ green (high accent)
+        "reverse_z": True,  # draw high→low so the near-baseline curves sit on top
+        "cbar_label": "Hz",
+        "fmt": "{:.0f}",
+        "sweep": (150.0, 5000.0, "log"),
+        # Split below/above the baseline peak: the broad peaks overlap, so one
+        # colour would paint over the other (same as the slope tile).
+        "split": "value",
+        "zoom_xlim": (100.0, 5000.0),
+        "xscale": "log",
+        "x_unit": "kHz",
+        "region_kind": "axvspan_peak",  # translucent band 200-3000 Hz
+    },
+    {
+        "knob": "spectral_slope",
+        "label": "High-frequency spectral slope",
+        "color": "#ff7f0e",
+        "low_color": "#7e3ca2",  # purple (low) ↔ orange (high accent)
+        "cbar_label": "slope",
+        "fmt": "{:+.1f}",
+        "sweep": (-3.0, 3.0, "linear"),
+        # Split below/above the baseline slope: the two fans overlap heavily
+        # around the peak, so one colour would paint over the other.
+        "split": "value",
+        "zoom_xlim": (500.0, FS_HZ / 2.0),
+        "xscale": "log",
+        "x_unit": "kHz",
+        "region_kind": "diagonal_arrow",  # diagonal arrow over 1–5 kHz
+    },
+]
+
+
+def _make_noise(prof: dict, *, seed: int = 0) -> np.ndarray:
+    set_random_seed(seed)
+    return generate_realistic_noise(
+        N_SAMPLES,
+        FS_HZ,
+        noise_rms=prof["noise_floor_uv"],
+        spectral_slope=prof["spectral_slope"],
+        excess_kurtosis=prof["excess_kurtosis"],
+        powerline_hz=prof["powerline_hz"],
+        powerline_amplitude=prof["powerline_amplitude"],
+        powerline_harmonic_ratios=prof["powerline_harmonic_ratios"],
+        peak_hz=prof["peak_hz"],
+        analog_hpf_hz=prof["analog_hpf_hz"],
+    )
+
+
+def _psd(noise: np.ndarray, nperseg: int = 4096) -> tuple[np.ndarray, np.ndarray]:
+    nperseg = min(N_SAMPLES, nperseg)
+    freqs, psd = sig.welch(
+        noise,
+        fs=FS_HZ,
+        nperseg=nperseg,
+        noverlap=int(nperseg * 0.75),
+        average="median",
+    )
+    return freqs, 10.0 * np.log10(np.maximum(psd, 1e-30))
+
+
+def _sweep_values(lo: float, hi: float, n: int, scale: str) -> np.ndarray:
+    return np.geomspace(lo, hi, n) if scale == "log" else np.linspace(lo, hi, n)
+
+
+def _smooth(psd_db: np.ndarray, sigma: float) -> np.ndarray:
+    """Gaussian-smooth a dB curve (no-op when sigma is 0)."""
+    return gaussian_filter1d(psd_db, sigma=sigma, mode="nearest") if sigma else psd_db
+
+
+def _scaled(v, scale: str):
+    """Map values into the domain the colour norm lives in (log10 for log)."""
+    return np.log10(v) if scale == "log" else v
+
+
+def _diverging_cmap(low_color: str, high_color: str) -> mcolors.Colormap:
+    """Baseline-centred diverging map from an explicit (low, high) colour pair.
+
+    Near-black centre → light tint of each hue at the extremes, so curves grow
+    OUT of the black baseline line and fade lighter as they deviate. Using
+    explicit colours (rather than a named ColorBrewer map) lets every tile pick
+    a fully distinct hue pair so no two tiles look alike.
+    """
+    white = np.array([1.0, 1.0, 1.0])
+    dark = np.array([0.10, 0.10, 0.10])  # near-black centre
+    lo_hue = np.array(mcolors.to_rgb(low_color))
+    hi_hue = np.array(mcolors.to_rgb(high_color))
+    lo_end = lo_hue + (white - lo_hue) * 0.5  # light tint at low extreme
+    hi_end = hi_hue + (white - hi_hue) * 0.5
+    return mcolors.LinearSegmentedColormap.from_list("div", [lo_end, lo_hue, dark, hi_hue, hi_end])
+
+
+def _visible_minmax(curves: list, xlim: tuple) -> tuple[float, float]:
+    """Min/max dB across all curves inside the visible x-window."""
+    chunks = []
+    for f, p in curves:
+        m = (f >= xlim[0]) & (f <= xlim[1])
+        if np.any(m):
+            chunks.append(p[m])
+    allv = np.concatenate(chunks)
+    return float(allv.min()), float(allv.max())
+
+
+def _padded_ylim(
+    lo: float, hi: float, *, frac: float = 0.06, floor: float = 1.0
+) -> tuple[float, float]:
+    """Symmetric margin around a data range (fraction of span, min ``floor``)."""
+    margin = max((hi - lo) * frac, floor)
+    return lo - margin, hi + margin
+
+
+# Precompute baseline PSD — same in every tile.
+freqs_base, psd_db_base = _psd(_make_noise(BASELINE))
+
+##############################################################################
+# Figure layout: 3-row gridspec (overview + 2 rows of zoom tiles)
+# ---------------------------------------------------------------
+
+fig = plt.figure(figsize=(5.102, 3.0))
+gs = gridspec.GridSpec(3, 3, figure=fig, height_ratios=[0.6, 1.0, 1.0], hspace=0.62, wspace=0.55)
+
+ax_overview = fig.add_subplot(gs[0, :])
+# Build the six tile axes. The "split" knob (powerline fundamental) keeps its
+# grid cell but is rendered as two sub-panels later, so its slot is a None
+# placeholder here and the cell is stashed for that dedicated block.
+zoom_axes: list = []
+split_cells: dict = {}
+for i in range(6):
+    cell = gs[1 + i // 3, i % 3]
+    if SWEEPS[i].get("split"):
+        split_cells[i] = cell
+        zoom_axes.append(None)
+    else:
+        zoom_axes.append(fig.add_subplot(cell))
+
+##############################################################################
+# Top overview — baseline PSD with colour-coded region markers
+# ------------------------------------------------------------
+
+ax_overview.semilogx(
+    freqs_base,
+    psd_db_base,
+    color="#111111",
+    linewidth=0.8,
+    label="Baseline noise PSD",
+    zorder=10,
+)
+ax_overview.set_xlim(2.0, FS_HZ / 2.0)
+ax_overview.set_xticks([2, 10, 50, 100, 500, 1000, 5000])
+ax_overview.get_xaxis().set_major_formatter(ScalarFormatter())
+ax_overview.minorticks_off()
+ax_overview.set_xlabel("Frequency (Hz)")
+ax_overview.set_ylabel("PSD (dB)")
+ax_overview.grid(True, axis="y", alpha=0.22, linewidth=0.4)
+# Colour mapping by knob.
+color_map = {spec["knob"]: spec["color"] for spec in SWEEPS}
+
+# Anatomy callouts: leader lines pointing from a label at the top (or bottom)
+# straight at the spectral feature each knob creates, coloured to match the
+# tile below. Headroom is added above (and a little below) for the labels.
+ymin, ymax = ax_overview.get_ylim()
+yspan = ymax - ymin
+ax_overview.set_ylim(ymin - 0.06 * yspan, ymax + 0.55 * yspan)
+top_a = ymax + 0.42 * yspan  # upper label row
+top_b = ymax + 0.16 * yspan  # staggered lower label row
+floor_y = ymin - 0.00 * yspan  # below-curve label for the broadband floor
+
+
+def _curve_db(f: float) -> float:
+    return float(np.interp(f, freqs_base, psd_db_base))
+
+
+def _callout(
+    text: str, color: str, tip_f: float, txt_f: float, txt_y: float, ha: str = "center"
+) -> None:
+    ax_overview.annotate(
+        text,
+        xy=(tip_f, _curve_db(tip_f)),
+        xytext=(txt_f, txt_y),
+        color=color,
+        fontsize=4.3,
+        fontweight="bold",
+        ha=ha,
+        va="center",
+        zorder=8,
+        annotation_clip=False,
+        arrowprops=dict(arrowstyle="-|>", color=color, lw=0.7, shrinkA=3, shrinkB=4),
+    )
+
+
+_callout("Analog\nhigh-pass roll-off", color_map["analog_hpf_hz"], 5.0, 4.5, top_a)
+_callout("Powerline\n(50 / 100 / 150 Hz)", color_map["powerline_amplitude"], 50.0, 55.0, top_b)
+_callout("Mid-band peak\n(broad)", color_map["peak_hz"], 500.0, 500.0, top_a)
+_callout("High-frequency slope", color_map["spectral_slope"], 3000.0, 3400.0, top_b)
+_callout("Broadband noise floor", color_map["noise_floor_uv"], 350.0, 350.0, floor_y)
+
+
+def _panel_letter(ax, letter: str, *, dx: float = -0.06) -> None:
+    """Bold lower-case panel tag in the top-left corner (Nature style)."""
+    ax.text(
+        dx,
+        1.05,
+        letter,
+        transform=ax.transAxes,
+        fontsize=7,
+        fontweight="bold",
+        color="#111111",
+        ha="right",
+        va="bottom",
+    )
+
+
+_panel_letter(ax_overview, "a", dx=-0.035)
+
+##############################################################################
+# Bottom — dense colour-mapped zoom tiles, one per knob
+# -----------------------------------------------------
+
+tile_letters = ["b", "c", "d", "e", "f", "g"]
+
+for idx, (ax, spec) in enumerate(zip(zoom_axes, SWEEPS)):
+    if spec.get("split"):
+        continue  # rendered separately as two sub-panels (see below)
+    row, col = divmod(idx, 3)
+    color = spec["color"]
+    knob = spec["knob"]
+    label = spec["label"]
+    xscale = spec.get("xscale", "log")
+    lo, hi, scale = spec["sweep"]
+
+    values = _sweep_values(lo, hi, spec.get("n_sweep", N_SWEEP), scale)
+    baseline_val = BASELINE[knob]
+
+    # Diverging colour scale centred on the baseline: below → complement,
+    # above → knob colour, near-baseline → light. TwoSlopeNorm puts the
+    # baseline at the colormap centre regardless of where it sits in range.
+    s_lo, s_hi, s_base = (_scaled(lo, scale), _scaled(hi, scale), _scaled(baseline_val, scale))
+    norm = mcolors.TwoSlopeNorm(vmin=s_lo, vcenter=s_base, vmax=s_hi)
+    cmap = _diverging_cmap(spec["low_color"], spec["color"])
+
+    # Dense family of swept curves, shaded by value. Curves are intentionally
+    # unlabeled — the colourbar carries the mapping. For y_loglog tiles the
+    # curves are plotted as linear power (µV²/Hz) on a log y-axis below.
+    smooth_sig = spec.get("smooth_sigma", SMOOTH_SIGMA) if spec.get("smooth") else 0.0
+    loglog = spec.get("y_loglog", False)
+    relative = spec.get("relative", False)
+    logy = loglog or relative
+
+    def _yvals(psd_db):
+        if relative:  # ratio to baseline (× baseline)
+            return 10.0 ** ((psd_db - psd_db_base) / 10.0)
+        if loglog:  # linear power on a log axis
+            return 10.0 ** (psd_db / 10.0)
+        return psd_db
+
+    collected = []
+    for value in values:
+        prof = dict(BASELINE)
+        prof[knob] = value
+        freqs, psd_db = _psd(_make_noise(prof))
+        psd_db = _smooth(psd_db, smooth_sig)
+        ax.plot(
+            freqs,
+            _yvals(psd_db),
+            color=cmap(norm(_scaled(value, scale))),
+            linewidth=spec.get("curve_lw", CURVE_LW),
+            zorder=3,
+        )
+        collected.append((freqs, _yvals(psd_db)))
+
+    # Baseline on top in solid near-black — the reference curve.
+    base_curve = _smooth(psd_db_base, smooth_sig)
+    ax.plot(
+        freqs_base,
+        _yvals(base_curve),
+        color="#111111",
+        linewidth=0.8,
+        linestyle="-",
+        label=f"baseline ({spec['fmt'].format(baseline_val)})",
+        zorder=-1000,
+    )
+    collected.append((freqs_base, _yvals(base_curve)))
+
+    ax.set_xscale(xscale)
+
+    # X limits and ticks per knob.
+    xlim = spec["zoom_xlim"] if spec["zoom_xlim"] else (2.0, FS_HZ / 2.0)
+    ax.set_xlim(*xlim)
+    if xscale == "log":
+        candidate_ticks = [2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000]
+        log_width = float(np.log10(xlim[1] / xlim[0]))
+        min_log_spacing = max(0.18, log_width / 5.0)
+        in_range = [t for t in candidate_ticks if xlim[0] <= t <= xlim[1]]
+        ticks: list = [in_range[0]] if in_range else []
+        for t in in_range[1:]:
+            if np.log10(t / ticks[-1]) >= min_log_spacing:
+                ticks.append(t)
+        if ticks:
+            ax.set_xticks(ticks)
+        ax.minorticks_off()
+    else:
+        ax.set_xticks([40, 45, 50, 55, 60])
+    ax.get_xaxis().set_major_formatter(ScalarFormatter())
+
+    # Explicit y-limits derived from each tile's own data, so every tile
+    # frames its curves tightly instead of leaving dead space.
+    y_lo, y_hi = _visible_minmax(collected, xlim)
+    if logy:
+        ax.set_yscale("log")
+        ax.yaxis.set_minor_formatter(NullFormatter())  # no 9×10⁰-style minor labels
+        ax.set_ylim(y_lo * 0.6, y_hi * 1.6)  # multiplicative padding for log
+    else:
+        ax.set_ylim(*_padded_ylim(y_lo, y_hi))
+
+    ax.set_title(label, fontsize=5.5, loc="left", color="#111111", fontweight="bold", pad=3)
+    ax.grid(True, axis="y", alpha=0.22, linewidth=0.4)
+
+    # Slim colourbar just outside the right spine, matching the sweep cmap.
+    sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap)
+    cax = ax.inset_axes([1.03, 0.06, 0.045, 0.88])
+    cb = fig.colorbar(sm, cax=cax)
+    cb.outline.set_linewidth(0.4)
+    cb.ax.tick_params(labelsize=3.5, length=2.0, width=0.5, pad=1.5)
+    cb.set_label(spec["cbar_label"], fontsize=4.3, labelpad=2.0)
+    # Ticks at lo / baseline / hi (positions in the norm's scaled domain,
+    # labels in real units). The baseline sits at the diverging centre.
+    cb.set_ticks([s_lo, s_base, s_hi])
+    cb.set_ticklabels([spec["fmt"].format(v) for v in (lo, baseline_val, hi)])
+    # Mark the baseline on the colourbar (links to the black reference curve).
+    cax.axhline(s_base, color="#111111", linewidth=0.6, zorder=5)
+
+    # Axis labels only on the outside of the grid: y on column 0, x on bottom row.
+    if relative:
+        ax.set_ylabel("PSD / baseline (×)")
+    elif loglog:
+        ax.set_ylabel("PSD (µV²/Hz)")  # log y-axis of linear power
+    elif col == 0:
+        ax.set_ylabel("PSD (dB)")
+    else:
+        ax.set_ylabel("")
+    if row == 1:
+        ax.set_xlabel("Frequency (Hz)")
+    else:
+        ax.set_xlabel("")
+
+    _panel_letter(ax, tile_letters[idx])
+
+##############################################################################
+# Split tiles — two sub-panels (below / above baseline) so opposing halves
+# of a diverging sweep don't paint over each other
+# ----------------------------------------------------------------------------
+
+
+def _apply_xticks(ax, xlim, xscale, explicit=None):
+    """Tick logic shared with the main tiles (≈5 labels, no overlap)."""
+    if explicit is not None:
+        ax.set_xticks(explicit)
+    elif xscale == "log":
+        candidate = [2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000]
+        spacing = max(0.18, float(np.log10(xlim[1] / xlim[0])) / 5.0)
+        in_range = [t for t in candidate if xlim[0] <= t <= xlim[1]]
+        ticks = [in_range[0]] if in_range else []
+        for t in in_range[1:]:
+            if np.log10(t / ticks[-1]) >= spacing:
+                ticks.append(t)
+        if ticks:
+            ax.set_xticks(ticks)
+    ax.get_xaxis().set_major_formatter(ScalarFormatter())
+    ax.minorticks_off()
+
+
+def render_split_tile(spec, idx, cell):
+    cmap = _diverging_cmap(spec["low_color"], spec["color"])
+    knob = spec["knob"]
+    base = BASELINE[knob]
+    lo, hi, scale = spec["sweep"]
+    xscale = spec.get("xscale", "log")
+    n = spec.get("n_sweep", N_SWEEP)
+    zoom = spec["zoom_xlim"]
+    loglog = spec.get("y_loglog", False)
+    relative = spec.get("relative", False)
+    logy = loglog or relative
+    vertical = spec.get("split_dir") == "v"
+    smooth_sig = spec.get("smooth_sigma", SMOOTH_SIGMA) if spec.get("smooth") else 0.0
+    nps = spec.get("nperseg", 4096)
+
+    # Baseline-centred diverging norm shared by both sub-panels.
+    norm = mcolors.TwoSlopeNorm(
+        vmin=_scaled(lo, scale), vcenter=_scaled(base, scale), vmax=_scaled(hi, scale)
+    )
+
+    # Baseline PSD at the curves' resolution (recompute only if finer).
+    if nps == 4096:
+        base_f, base_p = freqs_base, psd_db_base
+    else:
+        base_f, base_p = _psd(_make_noise(BASELINE), nps)
+    base_ref = _smooth(base_p, smooth_sig)
+
+    def _yv(psd_db):
+        if relative:  # ÷ baseline → flat floor at 1
+            return 10.0 ** ((psd_db - base_ref) / 10.0)
+        if loglog:  # linear power on a log axis
+            return 10.0 ** (psd_db / 10.0)
+        return psd_db
+
+    y_label = "PSD / baseline (×)" if relative else "PSD (µV²/Hz)" if loglog else "PSD (dB)"
+
+    below_vals = _sweep_values(lo, base, n + 1, scale)[:-1]
+    above_vals = _sweep_values(base, hi, n + 1, scale)[1:]
+    below_title = f"below {spec['fmt'].format(base)}"
+    above_title = f"above {spec['fmt'].format(base)}"
+
+    def _plot_side(sax, vals, xl, xticks):
+        draw_vals = vals[::-1] if spec.get("reverse_z") else vals
+        for value in draw_vals:
+            prof = dict(BASELINE)
+            prof[knob] = value
+            freqs, psd_db = _psd(_make_noise(prof), nps)
+            psd_db = _smooth(psd_db, smooth_sig)
+            sax.plot(
+                freqs,
+                _yv(psd_db),
+                color=cmap(norm(_scaled(value, scale))),
+                linewidth=spec.get("curve_lw", CURVE_LW),
+                zorder=3,
+            )
+        sax.plot(base_f, _yv(base_ref), color="#111111", linewidth=0.8, zorder=-1000)
+        curves = [(base_f, _yv(base_ref))]
+        for value in vals:
+            prof = dict(BASELINE)
+            prof[knob] = value
+            f2, p2 = _psd(_make_noise(prof), nps)
+            curves.append((f2, _yv(_smooth(p2, smooth_sig))))
+        sax.set_xscale(xscale)
+        sax.set_xlim(*xl)
+        _apply_xticks(sax, xl, xscale, explicit=xticks)
+        if logy:
+            sax.set_yscale("log")
+            sax.yaxis.set_minor_formatter(NullFormatter())  # no minor tick labels
+        sax.grid(True, axis="y", alpha=0.22, linewidth=0.4)
+        mlo, mhi = _visible_minmax(curves, xl)
+        sax.set_ylim(*((mlo * 0.6, mhi * 1.6) if logy else _padded_ylim(mlo, mhi)))
+        return mlo, mhi
+
+    show_x = idx // 3 == 1  # only the bottom tile row carries the x-label text
+
+    def _xlabel(sax):
+        if spec.get("x_unit") == "kHz":
+            sax.get_xaxis().set_major_formatter(FuncFormatter(lambda v, _p: f"{v / 1000:g}"))
+            sax.set_xlabel("Frequency (kHz)" if show_x else "")
+        else:
+            sax.set_xlabel("Frequency (Hz)" if show_x else "")
+
+    if vertical:
+        # Stacked: above-baseline on top, below-baseline on bottom; shared x,
+        # independent y so each row auto-zooms to its own deviation range.
+        subgs = cell.subgridspec(2, 2, width_ratios=[1.0, 0.05], hspace=0.18, wspace=0.04)
+        ax_top = fig.add_subplot(subgs[0, 0])
+        ax_bot = fig.add_subplot(subgs[1, 0], sharex=ax_top)
+        cax = fig.add_subplot(subgs[:, 1])
+
+        _plot_side(ax_top, above_vals, zoom, None)
+        _plot_side(ax_bot, below_vals, zoom, None)
+        # One y-label centred across both rows (avoids the two stacked labels
+        # colliding in the middle).
+        ax_bot.set_ylabel(y_label)
+        ax_bot.yaxis.set_label_coords(-0.16, 1.0)
+        ax_top.tick_params(labelbottom=False)
+        _xlabel(ax_bot)
+        ax_top.set_title(
+            spec["label"], fontsize=5.5, loc="left", color="#111111", fontweight="bold", pad=3
+        )
+        _panel_letter(ax_top, tile_letters[idx])
+        cb_ax = cax
+        panes = [ax_top, ax_bot]
+    else:
+        independent_y = logy
+        subgs = cell.subgridspec(1, 2, wspace=0.10)
+        ax0 = fig.add_subplot(subgs[0, 0])
+        ax1 = (
+            fig.add_subplot(subgs[0, 1])
+            if independent_y
+            else fig.add_subplot(subgs[0, 1], sharey=ax0)
+        )
+        if spec["split"] == "freq":
+            sides = [
+                (ax0, below_vals, (lo, base), below_title, [40, 45, 50]),
+                (ax1, above_vals, (base, hi), above_title, [50, 55, 60]),
+            ]
+        else:
+            sides = [
+                (ax0, below_vals, zoom, below_title, None),
+                (ax1, above_vals, zoom, above_title, None),
+            ]
+        ranges = []
+        for sax, vals, xl, sub_title, xticks in sides:
+            ranges.append(_plot_side(sax, vals, xl, xticks))
+            _xlabel(sax)
+        if independent_y:
+            ax1.yaxis.tick_right()
+            ax1.tick_params(labelright=True, labelleft=False)
+        else:
+            # Shared y across both sides — compute the union from the DATA
+            # (sharey makes per-side set_ylim clobber each other otherwise).
+            whole_lo = min(r[0] for r in ranges)
+            whole_hi = max(r[1] for r in ranges)
+            ax0.set_ylim(*(_padded_ylim(whole_lo, whole_hi)))  # shared → both
+            ax1.tick_params(labelleft=False)
+            inner_shared_axes.append(ax1)  # redundant seam y-axis — stripped later
+        ax0.set_ylabel(y_label)
+        ax0.set_title(
+            spec["label"], fontsize=5.5, loc="left", color="#111111", fontweight="bold", pad=3
+        )
+        _panel_letter(ax0, tile_letters[idx])
+        cb_ax = ax1.inset_axes([1.22 if independent_y else 1.08, 0.06, 0.09, 0.88])
+        panes = [ax0, ax1]
+
+    # Shared diverging colourbar.
+    sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap)
+    cb = fig.colorbar(sm, cax=cb_ax)
+    cb.outline.set_linewidth(0.4)
+    cb.ax.tick_params(labelsize=3.5, length=2.0, width=0.5, pad=1.5)
+    cb.set_label(spec["cbar_label"], fontsize=4.3, labelpad=2.0)
+    cb.set_ticks([_scaled(lo, scale), _scaled(base, scale), _scaled(hi, scale)])
+    cb.set_ticklabels([spec["fmt"].format(v) for v in (lo, base, hi)])
+    cb_ax.axhline(_scaled(base, scale), color="#111111", linewidth=0.6, zorder=5)
+    return panes
+
+
+data_axes = [ax_overview] + [a for a in zoom_axes if a is not None]
+inner_shared_axes: list = []  # right sub-panels that share y with their left twin
+for _idx, _spec in enumerate(SWEEPS):
+    if _spec.get("split"):
+        data_axes.extend(render_split_tile(_spec, _idx, split_cells[_idx]))
+
+# Offset + trimmed spines on every data axis (not the colourbars).
+for _ax in data_axes:
+    sns.despine(ax=_ax, offset=2, trim=True)
+
+# Shared-y split twins: drop the redundant inner (seam) y-axis entirely.
+for _ax in inner_shared_axes:
+    _ax.spines["left"].set_visible(False)
+    _ax.tick_params(left=False, labelleft=False)
+
+fig.suptitle(
+    "Effect of each noise-model parameter on the simulated iEMG power spectrum",
+    fontsize=6.5,
+    fontweight="bold",
+    y=1.0,
+)
+plt.tight_layout(rect=(0, 0, 1, 0.97))
+# No bbox_inches="tight" so the saved canvas is exactly the figure size.
+fig.savefig(save_path / "noise_parameter_sweep.png", dpi=300, transparent=True)
+fig.savefig(save_path / "noise_parameter_sweep.svg", transparent=True)
+fig.savefig(save_path / "noise_parameter_sweep.pdf", transparent=True)
+plt.show()

--- a/myogen/simulator/core/emg/intramuscular/intramuscular_emg.py
+++ b/myogen/simulator/core/emg/intramuscular/intramuscular_emg.py
@@ -755,47 +755,142 @@ class IntramuscularEMG:
         self._intramuscular_emg__Block = block
         return block
 
-    def add_noise(self, snr__dB: float, noise_type: str = "gaussian") -> INTRAMUSCULAR_EMG__Block:
+    def add_noise(
+        self,
+        snr__dB: float,
+        noise_type: str = "gaussian",
+        *,
+        spectral_slope: float = -0.5,
+        excess_kurtosis: float = 3.0,
+        powerline_hz: float = 50.0,
+        powerline_amplitude: float = 0.1,
+        powerline_harmonic_ratios: Optional[list[float]] = None,
+        powerline_frequency_drift_hz: float = 0.3,
+        powerline_amplitude_modulation_depth: float = 0.15,
+        peak_hz: float = 1000.0,
+        analog_hpf_hz: float = 10.0,
+        baseline_drift_rms_uv: float = 0.0,
+        baseline_drift_alpha: float = 1.75,
+        baseline_drift_low_hz: float | None = None,
+        baseline_drift_high_hz: float = 1.0,
+    ) -> INTRAMUSCULAR_EMG__Block:
         """
         Add noise to the electrode array.
 
-        This method adds realistic noise to the simulated intramuscular EMG signals
-        based on a specified signal-to-noise ratio. The noise is calculated
-        and applied independently for each electrode channel to ensure that
-        channels with different signal amplitudes maintain the specified SNR.
+        Two noise models are available:
+
+        * ``"gaussian"`` – white Gaussian noise (legacy default). Each
+          electrode channel gets independent normal noise scaled to hit
+          the requested per-channel SNR.
+        * ``"realistic"`` – spectrally colored noise calibrated against
+          real bipolar fine-wire iEMG recordings (TEP / Synergy studies).
+          1/f-like base, mid-band spectral emphasis from
+          electrode–amplifier bandwidth, heavy tails from cross-talk
+          artifacts, and additive 50/60 Hz powerline interference with
+          harmonics. See :mod:`myogen.utils.emg_noise` for the math.
+
+        Per-channel SNR is preserved across both modes: each electrode's
+        noise RMS is computed from that channel's own signal RMS so
+        electrodes with different amplitudes get appropriately scaled
+        noise.
 
         Parameters
         ----------
         snr__dB : float
-            Signal-to-noise ratio in dB. Higher values result in cleaner signals.
-            Typical intramuscular EMG has SNR ranging from 15-50 dB.
-            The SNR is applied independently to each electrode channel.
-        noise_type : str, default="gaussian"
-            Type of noise to add. Currently supports "gaussian" for white noise.
+            Signal-to-noise ratio in dB. Higher values result in cleaner
+            signals. Typical intramuscular EMG has SNR ranging from
+            15–50 dB. Applied independently to each electrode channel.
+        noise_type : {"gaussian", "realistic"}, default="gaussian"
+            Noise model to use. ``"realistic"`` activates the colored
+            noise pipeline; the remaining keyword-only parameters then
+            apply.
+        spectral_slope : float, default=-0.5
+            PSD slope in log–log space for the colored-noise base.
+            ``0`` = white, ``-1`` = pink. Real iEMG: -0.4 to -0.8.
+            Ignored when ``noise_type="gaussian"``.
+        excess_kurtosis : float, default=3.0
+            Target excess kurtosis (``0`` = Gaussian). Controlled
+            isometric iEMG: 1–6. Dynamic tasks: higher.
+            Ignored when ``noise_type="gaussian"``.
+        powerline_hz : float, default=50.0
+            Powerline interference frequency. Use ``60.0`` for North
+            America, ``0.0`` to disable.
+            Ignored when ``noise_type="gaussian"``.
+        powerline_amplitude : float, default=0.1
+            Powerline fundamental amplitude as a fraction of noise RMS.
+            Set to ``0`` (or ``powerline_hz=0``) to disable.
+            Ignored when ``noise_type="gaussian"``.
+        powerline_harmonic_ratios : list of float, optional
+            Per-harmonic amplitude ratios relative to the fundamental.
+            ``None`` uses the default ``[1.0, 0.5, 0.3, 0.15, 0.08]``
+            (fundamental + 4 harmonics).
+            Ignored when ``noise_type="gaussian"``.
+        powerline_frequency_drift_hz : float, default=0.3
+            Standard deviation (Hz) of the slow random walk of the
+            mains instantaneous frequency. Broadens each line peak
+            from a delta into a ~2-5 Hz FWHM bump (typical of real
+            recordings). Set to 0 for a pure-tone powerline.
+            Ignored when ``noise_type="gaussian"``.
+        powerline_amplitude_modulation_depth : float, default=0.15
+            Fractional AM depth (±15% by default) applied to each
+            powerline harmonic — adds narrow sidebands within ±2 Hz
+            of every line. Set to 0 to disable.
+            Ignored when ``noise_type="gaussian"``.
+        peak_hz : float, default=1000.0
+            Center frequency of the mid-band spectral emphasis from
+            electrode–amplifier bandwidth interaction.
+            Ignored when ``noise_type="gaussian"``.
+        baseline_drift_rms_uv : float, default=0.0
+            Target RMS (post-HPF) of a band-limited 1/f^α baseline
+            drift representing electrode/interface noise (Huigen 2002,
+            Gondran 1996). Same units as the EMG block. Set to 0 (the
+            default) to disable, preserving legacy behaviour.
+            The spectral form is paper-constrained; the amplitude
+            defaults are *not* validated for intramuscular EMG —
+            calibrate against real recordings via
+            :func:`myogen.utils.calibrate_baseline_drift_profile`.
+            Broadband movement artifacts (0–20 Hz, De Luca 2010) are
+            a separate phenomenon out of scope here.
+            Ignored when ``noise_type="gaussian"``.
+        baseline_drift_alpha : float, default=1.75
+            Drift PSD slope α (PSD ∝ 1/f^α). Midpoint of the [1.5, 2.0]
+            electrode-noise regime. Must be > 0.
+            Ignored when ``noise_type="gaussian"``.
+        baseline_drift_low_hz : float or None, default=None
+            Lower edge of the drift band, in Hz. ``None`` resolves
+            to the lowest nonzero FFT bin available for the
+            simulation length.
+            Ignored when ``noise_type="gaussian"``.
+        baseline_drift_high_hz : float, default=1.0
+            Upper edge of the drift band, in Hz. Default keeps the
+            knob scoped to sub-1 Hz baseline wander.
+            Ignored when ``noise_type="gaussian"``.
 
         Returns
         -------
         INTRAMUSCULAR_EMG__Block
-            Noisy intramuscular EMG signals for the electrode array as a neo.Block.
-            Results are stored in the `noisy_intramuscular_emg__Block` property after execution.
+            Noisy intramuscular EMG signals for the electrode array as a
+            ``neo.Block``. Results are also stored on
+            ``noisy_intramuscular_emg__Block``.
 
         Raises
         ------
         ValueError
-            If intramuscular EMG has not been simulated. Call simulate_intramuscular_emg() first.
-
-        Notes
-        -----
-        The noise is computed per-channel (per electrode) to maintain the specified
-        SNR independently across all channels. This ensures that electrodes with
-        different signal amplitudes receive appropriately scaled noise.
+            If intramuscular EMG has not been simulated (call
+            :meth:`simulate_intramuscular_emg` first) or ``noise_type``
+            is unrecognized.
         """
         if self._intramuscular_emg__Block is None:
             raise ValueError(
                 "Intramuscular EMG has not been simulated. Call simulate_intramuscular_emg() first."
             )
 
+        noise_kind = noise_type.lower()
+        if noise_kind not in ("gaussian", "realistic"):
+            raise ValueError(f"Unsupported noise type: {noise_type}")
+
         noisy_block = Block()
+        rng_global = get_random_generator()
 
         for pool_idx, segment in enumerate(self._intramuscular_emg__Block.segments):
             noisy_segment = Segment(name=f"Pool_{pool_idx}")
@@ -814,17 +909,40 @@ class IntramuscularEMG:
             noise_power_per_channel = signal_power_per_channel / snr_linear
             noise_std_per_channel = np.sqrt(noise_power_per_channel)  # Shape: (n_electrodes,)
 
-            # Generate noise
-            if noise_type.lower() == "gaussian":
+            if noise_kind == "gaussian":
                 # Generate standard normal noise, then scale per channel
-                noise = get_random_generator().normal(loc=0.0, scale=1.0, size=emg_array.shape)
-                # Broadcast noise_std_per_channel along time axis
-                # noise shape: (time, n_electrodes)
-                # noise_std_per_channel shape: (n_electrodes,)
-                # Broadcasting: (time, n_electrodes) * (1, n_electrodes)
+                noise = rng_global.normal(loc=0.0, scale=1.0, size=emg_array.shape)
                 noise = noise * noise_std_per_channel[np.newaxis, :]
             else:
-                raise ValueError(f"Unsupported noise type: {noise_type}")
+                # Colored noise (signal-shape preserving SNR semantics).
+                # Per-channel call so each electrode hits the requested SNR
+                # individually, matching the legacy gaussian path.
+                from myogen.utils.emg_noise import generate_realistic_noise
+
+                n_samples, n_channels = emg_array.shape
+                fs_hz = float(self._sampling_frequency__Hz)
+                noise = np.empty_like(emg_array)
+                for ch in range(n_channels):
+                    ch_rng = np.random.default_rng(rng_global.integers(0, 2**31 - 1))
+                    noise[:, ch] = generate_realistic_noise(
+                        n_samples,
+                        fs_hz,
+                        noise_rms=float(noise_std_per_channel[ch]),
+                        spectral_slope=spectral_slope,
+                        excess_kurtosis=excess_kurtosis,
+                        powerline_hz=powerline_hz,
+                        powerline_amplitude=powerline_amplitude,
+                        powerline_harmonic_ratios=powerline_harmonic_ratios,
+                        powerline_frequency_drift_hz=powerline_frequency_drift_hz,
+                        powerline_amplitude_modulation_depth=powerline_amplitude_modulation_depth,
+                        peak_hz=peak_hz,
+                        analog_hpf_hz=analog_hpf_hz,
+                        baseline_drift_rms_uv=baseline_drift_rms_uv,
+                        baseline_drift_alpha=baseline_drift_alpha,
+                        baseline_drift_low_hz=baseline_drift_low_hz,
+                        baseline_drift_high_hz=baseline_drift_high_hz,
+                        rng=ch_rng,
+                    )
 
             # Add noise
             noisy_emg = emg_array + noise

--- a/myogen/utils/__init__.py
+++ b/myogen/utils/__init__.py
@@ -1,6 +1,14 @@
 """MyoGen utility functions and helpers."""
 
 from myogen.utils.continuous_saver import ContinuousSaver, convert_chunks_to_neo
+from myogen.utils.emg_noise import (
+    add_realistic_noise,
+    calibrate_baseline_drift_profile,
+    calibrate_realistic_noise_profile,
+    generate_realistic_noise,
+    estimate_noise_rms_from_recording,
+    tune_noise_profile_with_optuna,
+)
 from myogen.utils.neo import (
     create_grid_signal,
     signal_to_grid,
@@ -39,4 +47,11 @@ __all__ = [
     "export_to_nwb",
     "export_simulation_to_nwb",
     "validate_nwb",
+    # Colored EMG noise model (iEMG-calibrated)
+    "add_realistic_noise",
+    "calibrate_baseline_drift_profile",
+    "calibrate_realistic_noise_profile",
+    "generate_realistic_noise",
+    "estimate_noise_rms_from_recording",
+    "tune_noise_profile_with_optuna",
 ]

--- a/myogen/utils/emg_noise.py
+++ b/myogen/utils/emg_noise.py
@@ -1,0 +1,1448 @@
+"""
+Realistic intramuscular EMG noise model.
+
+Based on analysis of real bipolar fine-wire iEMG recordings (vastus
+medialis / lateralis, stainless-steel bipolar electrodes).
+
+Key findings that inform the model:
+  1. Noise is signal-independent (constant floor, not SNR-scaled).
+     The HF noise floor during rest vs active contraction is identical
+     (ratio ~0.9-1.0 across studies).
+  2. Noise is spectrally colored with a mid-band emphasis.  The PSD
+     peaks around 500-1000 Hz (from electrode/amplifier characteristics)
+     with a slope of ~-0.5 above the peak.
+  3. Amplitude distribution has heavier tails than Gaussian
+     (excess kurtosis 1-6 for controlled isometric, higher for
+     dynamic tasks).
+
+Usage:
+    from iemg_noise import add_realistic_noise
+
+    noisy = add_realistic_noise(
+        clean_emg,
+        fs_hz=10240,
+        target_snr_db=20.0,   # SNR determines noise floor amplitude
+        spectral_slope=-0.5,
+    )
+
+The noise_rms is computed from the signal's active-period RMS and the
+target_snr_db, then applied as a CONSTANT floor (same amplitude during
+rest and contraction).  This matches real recordings where the noise
+floor is instrumental, not physiological.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy import signal as sig
+
+
+def _colored_noise(
+    n_samples: int,
+    fs_hz: float,
+    spectral_slope: float,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Generate colored noise with a given spectral slope.
+
+    Uses the spectral-shaping method: generate white noise in the
+    frequency domain, multiply by |f|^(slope/2), inverse FFT.
+
+    Parameters
+    ----------
+    n_samples : int
+        Number of output samples.
+    fs_hz : float
+        Sampling rate (Hz).
+    spectral_slope : float
+        PSD slope in log-log space.  0 = white, -1 = pink, -2 = brown.
+        Typical iEMG noise: -0.4 to -0.8.
+    rng : np.random.Generator
+        Random number generator.
+
+    Returns
+    -------
+    ndarray
+        Noise signal, zero-mean, unit variance.
+    """
+    n_fft = n_samples + (n_samples % 2)  # ensure even
+
+    # White noise in frequency domain (complex Gaussian)
+    white = rng.standard_normal(n_fft) + 1j * rng.standard_normal(n_fft)
+
+    # Frequency axis
+    freqs = np.fft.fftfreq(n_fft, d=1.0 / fs_hz)
+
+    # Shaping filter: |f|^(slope/2) for PSD slope
+    # Avoid DC (f=0) — set it to 0 to remove DC offset
+    shape = np.zeros(n_fft)
+    nonzero = freqs != 0
+    shape[nonzero] = np.abs(freqs[nonzero]) ** (spectral_slope / 2.0)
+
+    # Apply shaping
+    colored = np.fft.ifft(white * shape).real[:n_samples]
+
+    # Normalize to unit variance
+    std = colored.std()
+    if std > 0:
+        colored /= std
+
+    return colored
+
+
+def _add_powerline(
+    noise: np.ndarray,
+    fs_hz: float,
+    freq_hz: float,
+    amplitude_fraction: float,
+    rng: np.random.Generator,
+    harmonic_ratios: list[float] | None = None,
+    frequency_drift_hz: float = 0.3,
+    amplitude_modulation_depth: float = 0.15,
+) -> np.ndarray:
+    """Add powerline interference with harmonics, frequency drift, and AM.
+
+    Powerline is applied as an additional layer on top of the device
+    noise colour — the fundamental at ``freq_hz`` plus harmonics with
+    amplitudes scaled by ``harmonic_ratios``. This matches real
+    recordings where 100 / 150 / 200 Hz harmonics often have comparable
+    energy to the fundamental.
+
+    Real mains frequency is not exactly 50 or 60 Hz — it wanders
+    ±0.05–0.2 Hz on multi-second timescales (frequency containment
+    reserve, load shifts), and the amplitude wobbles a few percent
+    from load coupling. Modelling these as a slow random walk in the
+    instantaneous frequency plus a low-pass-modulated amplitude
+    envelope turns the PSD line from a delta-like spike into a curved
+    peak with shoulders/sidebands — exactly what is observed in real
+    recordings.
+
+    Parameters
+    ----------
+    noise : ndarray
+        Input noise signal.
+    fs_hz : float
+        Sampling rate.
+    freq_hz : float
+        Powerline fundamental (50 or 60 Hz).
+    amplitude_fraction : float
+        Amplitude of the fundamental as a fraction of noise RMS.
+        Typical: 0.05-0.3 depending on grounding quality.
+    rng : np.random.Generator
+        Random generator (for random per-harmonic phases and the
+        frequency drift trajectory).
+    harmonic_ratios : list of float, optional
+        Amplitude ratios of harmonics relative to the fundamental.
+        ``harmonic_ratios[0]`` multiplies the fundamental (default 1.0),
+        ``harmonic_ratios[1]`` the 2nd harmonic (2× freq_hz), etc.
+        Default: ``[1.0, 0.5, 0.3, 0.15, 0.08]`` (50, 100, 150, 200, 250 Hz).
+    frequency_drift_hz : float, default 0.3
+        Standard deviation of the slow instantaneous-frequency drift of
+        the fundamental, in Hz. Harmonics drift proportionally (k× the
+        fundamental). Set to 0 for a pure-tone powerline (sharp delta
+        in the PSD). 0.3 Hz is a phenomenological default that reproduces
+        the typical 2–5 Hz FWHM of real-recording mains peaks (covers
+        grid frequency drift + ground-loop variations + window leakage).
+    amplitude_modulation_depth : float, default 0.15
+        Fractional AM depth applied to the powerline carriers. 0.15
+        means the envelope wobbles by roughly ±15%. The modulating
+        signal is low-pass filtered noise (cutoff ~2 Hz) so sidebands
+        appear within ±2 Hz of each line. Set to 0 to disable.
+
+    Returns
+    -------
+    ndarray
+        Noise with powerline + harmonics added.
+    """
+    if harmonic_ratios is None:
+        harmonic_ratios = [1.0, 0.5, 0.3, 0.15, 0.08]
+
+    n = len(noise)
+    nyq = fs_hz / 2.0
+    base = amplitude_fraction * noise.std()
+
+    # Slow frequency drift of the fundamental — low-pass-filtered random
+    # walk normalised to the requested std. Cutoff ~0.5 Hz so the drift
+    # varies on multi-second timescales like real grid frequency.
+    if frequency_drift_hz > 0:
+        drift = rng.standard_normal(n)
+        sos_drift = sig.butter(2, 0.5 / nyq, btype="low", output="sos")
+        drift = sig.sosfiltfilt(sos_drift, drift)
+        drift_std = drift.std()
+        if drift_std > 0:
+            drift = drift * (frequency_drift_hz / drift_std)
+    else:
+        drift = np.zeros(n)
+
+    # Slow amplitude modulation — low-pass-filtered white noise centred
+    # at 1.0, generating ±depth wobble that produces narrow sidebands
+    # around each harmonic.
+    if amplitude_modulation_depth > 0:
+        am = rng.standard_normal(n)
+        sos_am = sig.butter(2, 2.0 / nyq, btype="low", output="sos")
+        am = sig.sosfiltfilt(sos_am, am)
+        am_std = am.std()
+        if am_std > 0:
+            am = 1.0 + amplitude_modulation_depth * (am / am_std)
+        else:
+            am = np.ones(n)
+        am = np.clip(am, 0.0, None)
+    else:
+        am = np.ones(n)
+
+    powerline = np.zeros(n)
+    for k, ratio in enumerate(harmonic_ratios):
+        f_base = freq_hz * (k + 1)
+        if f_base >= nyq or ratio <= 0:
+            continue
+        # Instantaneous frequency = f_base + (k+1) * drift  (harmonics
+        # share the mains drift, scaled by the harmonic order).
+        f_inst = f_base + (k + 1) * drift
+        # Instantaneous phase = 2π ∫ f(t) dt, plus a random offset.
+        phase_inst = 2.0 * np.pi * np.cumsum(f_inst) / fs_hz
+        phase_inst += rng.uniform(0, 2 * np.pi)
+        powerline += base * ratio * am * np.sin(phase_inst)
+    return noise + powerline
+
+
+def _make_heavy_tailed(
+    noise: np.ndarray,
+    excess_kurtosis: float,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Reshape noise to have heavier tails (higher kurtosis).
+
+    Uses a sparse-spike approach: replace a small fraction of samples
+    with larger values drawn from a heavier distribution.  This mimics
+    the occasional artifacts and cross-talk spikes seen in real iEMG.
+
+    Parameters
+    ----------
+    noise : ndarray
+        Input noise (should be zero-mean, unit-ish variance).
+    excess_kurtosis : float
+        Target excess kurtosis (0 = Gaussian, 3-6 = typical real iEMG).
+    rng : np.random.Generator
+        Random generator.
+
+    Returns
+    -------
+    ndarray
+        Noise with heavier tails, re-normalized to original std.
+    """
+    if excess_kurtosis <= 0.5:
+        return noise
+
+    original_std = noise.std()
+
+    # Conservative spike injection — fewer, smaller spikes than before.
+    # Real iEMG kurtosis (1-6) comes from a small fraction of outliers.
+    spike_frac = min(0.005, excess_kurtosis / 2000.0)
+    n_spikes = max(1, int(len(noise) * spike_frac))
+
+    # t-distribution with moderate df for controlled tail weight
+    df = max(4.0, 12.0 - excess_kurtosis)
+    spike_amplitudes = rng.standard_t(df, size=n_spikes)
+
+    # Scale: 3-5x noise std (not 3-8x as before)
+    spike_scale = 2.5 + excess_kurtosis * 0.3
+    spike_amplitudes *= spike_scale
+
+    # Insert at random positions
+    positions = rng.choice(len(noise), size=n_spikes, replace=False)
+    noise = noise.copy()
+    noise[positions] += spike_amplitudes
+
+    # Re-normalize to original std
+    noise *= original_std / noise.std()
+
+    return noise
+
+
+def _emg_band_shape(
+    noise: np.ndarray,
+    fs_hz: float,
+    peak_hz: float = 1000.0,
+    bandwidth_hz: float = 1400.0,
+    emphasis_blend: float = 0.40,
+) -> np.ndarray:
+    """Shape noise to emphasize the EMG band (200-1800 Hz).
+
+    Real iEMG noise has a mild spectral peak in the 500-1500 Hz range
+    (from electrode-tissue interface and amplifier bandwidth) but its
+    overall shape is a smooth monotonic decay in log-log, not a sharp
+    resonance. This function applies a broad, low-order bandpass blended
+    with the broadband colour to preserve a continuous PSD without the
+    bumps a narrow high-order filter introduces.
+
+    Parameters
+    ----------
+    noise : ndarray
+        Input noise signal.
+    fs_hz : float
+        Sampling rate.
+    peak_hz : float, default 1000.0
+        Center frequency of the spectral emphasis.
+    bandwidth_hz : float, default 1400.0
+        Bandwidth around the peak — wide enough to avoid bulges.
+    emphasis_blend : float, default 0.40
+        Fraction of bandpass-emphasized signal in the blend. Lower
+        values produce smoother PSDs closer to monotonic decay.
+
+    Returns
+    -------
+    ndarray
+        Spectrally shaped noise, variance restored.
+
+    Notes
+    -----
+    The analog HPF that strips infra-low drift is handled in a separate
+    explicit stage inside :func:`generate_realistic_noise`
+    (``analog_hpf_hz``), so this function performs only the band
+    emphasis. Stacking two HPFs here would double the rolloff order
+    and cut the PSD below the cutoff far steeper than any real device.
+    """
+    nyq = fs_hz / 2.0
+    original_std = noise.std()
+
+    # Broad 2nd-order bandpass emphasis — low order avoids ringing/ripple
+    # that shows up as bulges in the PSD of the shaped noise.
+    low_bp = max((peak_hz - bandwidth_hz / 2) / nyq, 0.01)
+    high_bp = min((peak_hz + bandwidth_hz / 2) / nyq, 0.99)
+    sos_bp = sig.butter(2, [low_bp, high_bp], btype="band", output="sos")
+    emphasis = sig.sosfiltfilt(sos_bp, noise)
+
+    # Blend: modest emphasis + dominant broadband
+    blended = emphasis_blend * emphasis + (1 - emphasis_blend) * noise
+
+    # Restore variance
+    blended *= original_std / max(blended.std(), 1e-12)
+
+    return blended
+
+
+def _baseline_drift(
+    n_samples: int,
+    fs_hz: float,
+    target_rms: float,
+    alpha: float,
+    low_hz: float,
+    high_hz: float,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Generate band-limited 1/f^α baseline drift at a target RMS.
+
+    Models the slow low-frequency wander seen in real recordings —
+    electrode/interface noise, postural shifts, breathing, sweating.
+
+    Spectral form is paper-constrained: PSD ∝ ``1/f^alpha`` over an
+    explicit band ``[low_hz, high_hz]`` and zero outside, consistent
+    with Huigen, Peper & Grimbergen 2002 (DOI 10.1007/BF02344216) and
+    Gondran et al. 1996 (DOI 10.1007/BF02523851), which report α in
+    the 1.5–2.0 range for electrode/interface noise. The hard band
+    limit (rather than a Lorentzian rolloff) keeps the model scoped
+    to baseline wander; broadband movement artifacts (0–20 Hz per
+    De Luca et al. 2010, DOI 10.1016/j.jbiomech.2010.01.027) are a
+    separate phenomenon and require a different contaminant model.
+
+    The drift represents the residual that survives the amplifier's
+    analog HPF — added after the broadband HPF stage so the caller
+    sees the same amplitude they requested. A downstream user-applied
+    HPF will attenuate it further (realistic).
+
+    Public input validation lives in :func:`generate_realistic_noise`;
+    this helper assumes its arguments have already been checked.
+    """
+    if target_rms == 0 or n_samples < 4:
+        return np.zeros(n_samples)
+
+    n_fft = n_samples + (n_samples % 2)
+    white = rng.standard_normal(n_fft) + 1j * rng.standard_normal(n_fft)
+    freqs = np.fft.fftfreq(n_fft, d=1.0 / fs_hz)
+    abs_freqs = np.abs(freqs)
+
+    shape = np.zeros(n_fft)
+    band = (abs_freqs > 0) & (abs_freqs >= low_hz) & (abs_freqs <= high_hz)
+    if not np.any(band):
+        # No FFT bin landed in [low_hz, high_hz] — recording too short
+        # for the requested baseline-drift band. Caller is responsible
+        # for raising; this helper just returns zeros.
+        return np.zeros(n_samples)
+    shape[band] = abs_freqs[band] ** (-alpha / 2.0)
+
+    drift = np.fft.ifft(white * shape).real[:n_samples]
+    drift -= float(np.mean(drift))
+
+    rms = float(np.sqrt(np.mean(drift ** 2)))
+    if rms > 0:
+        drift *= target_rms / rms
+
+    return drift
+
+
+def generate_realistic_noise(
+    n_samples: int,
+    fs_hz: float,
+    noise_rms: float,
+    *,
+    spectral_slope: float = -0.5,
+    excess_kurtosis: float = 3.0,
+    powerline_hz: float = 50.0,
+    powerline_amplitude: float = 0.1,
+    powerline_harmonic_ratios: list[float] | None = None,
+    powerline_frequency_drift_hz: float = 0.3,
+    powerline_amplitude_modulation_depth: float = 0.15,
+    peak_hz: float = 1000.0,
+    analog_hpf_hz: float = 10.0,
+    baseline_drift_rms_uv: float = 0.0,
+    baseline_drift_alpha: float = 1.75,
+    baseline_drift_low_hz: float | None = None,
+    baseline_drift_high_hz: float = 1.0,
+    rng: np.random.Generator | None = None,
+) -> np.ndarray:
+    """Generate a single channel of realistic iEMG noise.
+
+    Parameters
+    ----------
+    n_samples : int
+        Length of the noise signal.
+    fs_hz : float
+        Sampling rate (Hz).
+    noise_rms : float
+        RMS amplitude of the noise floor (same units as EMG signal).
+    spectral_slope : float, default -0.5
+        PSD slope.  0 = white, -1 = pink.  Real iEMG: -0.4 to -0.8.
+    excess_kurtosis : float, default 3.0
+        Target excess kurtosis (0 = Gaussian).
+        Controlled isometric: 1-6.  Dynamic tasks: 10-50.
+    powerline_hz : float, default 50.0
+        Powerline frequency.  Set to 0 to disable.
+    powerline_amplitude : float, default 0.1
+        Powerline amplitude as fraction of noise RMS.
+    powerline_harmonic_ratios : list of float, optional
+        Per-harmonic amplitude ratios relative to the fundamental.
+        ``None`` uses the default ``[1.0, 0.5, 0.3, 0.15, 0.08]``.
+    powerline_frequency_drift_hz : float, default 0.3
+        Standard deviation of the slow random walk of the mains
+        instantaneous frequency. Broadens the 50/60 Hz line peak from
+        a delta into a ~2-5 Hz FWHM bump (typical of real recordings).
+        Set to 0 for a pure-tone powerline.
+    powerline_amplitude_modulation_depth : float, default 0.15
+        Fractional AM depth on the powerline carriers (~15% wobble).
+        Produces narrow sidebands within ±2 Hz of each line. Set to
+        0 to disable.
+    peak_hz : float, default 750.0
+        Center of the EMG-band spectral emphasis.
+    analog_hpf_hz : float, default 10.0
+        Analog HPF cutoff applied before the powerline is mixed in.
+        Mimics the amp's input AC-coupling. Set to 0 to disable.
+    baseline_drift_rms_uv : float, default 0.0
+        Target RMS of the band-limited 1/f^α baseline drift (post-HPF
+        residual). Same units as ``noise_rms``. Set to 0 to disable
+        — that is the default, keeping legacy behaviour unchanged.
+        Must be >= 0.
+
+        Spectral form is paper-constrained: PSD ∝ 1/f^α over an
+        explicit band ``[baseline_drift_low_hz, baseline_drift_high_hz]``,
+        consistent with electrode/interface noise studies (Huigen,
+        Peper & Grimbergen 2002, DOI 10.1007/BF02344216; Gondran
+        et al. 1996, DOI 10.1007/BF02523851). The default α=1.75 and
+        ``high_hz=1.0`` are the midpoint and upper bound of the
+        reported electrode-noise regime, not validated physiological
+        constants for intramuscular EMG. Calibrate against real
+        recordings via :func:`calibrate_baseline_drift_profile` if
+        you need amplitude-accurate simulation. Movement artifacts
+        (broadband, 0–20 Hz per De Luca et al. 2010, DOI
+        10.1016/j.jbiomech.2010.01.027) are a separate phenomenon
+        and would need their own contaminant model.
+
+        .. note::
+           **SNR contract**: drift is **additive on top** of the
+           broadband noise. ``noise_rms`` still controls the
+           broadband floor exactly, but enabling drift makes the
+           total noise RMS slightly higher
+           (``sqrt(noise_rms**2 + drift_rms**2)``). If you are
+           using ``snr__dB`` upstream to hit a target SNR, factor
+           this in or leave drift at 0.
+
+        .. note::
+           When called from a multi-channel context (e.g.
+           :func:`add_realistic_noise`), each channel receives an
+           **independent** drift realisation. Real electrode-array
+           drift is often partially common-mode across nearby
+           electrodes; this model does not capture that correlation.
+    baseline_drift_alpha : float, default 1.75
+        PSD slope α (positive number) for ``PSD ∝ 1/f^α``. Must be
+        > 0. The literature regime is α ∈ [1.5, 2.0]; the default
+        sits at the midpoint.
+    baseline_drift_low_hz : float or None, default None
+        Lower edge of the drift band, in Hz. ``None`` resolves to the
+        lowest nonzero FFT bin for the current segment length. Must
+        be > 0 when provided.
+    baseline_drift_high_hz : float, default 1.0
+        Upper edge of the drift band, in Hz. Must be > 0 and
+        < fs_hz / 2. The default keeps the model scoped to sub-1 Hz
+        baseline wander (see references above).
+    rng : np.random.Generator or None
+        Random generator.  Uses default if None.
+
+    Returns
+    -------
+    ndarray, shape (n_samples,)
+        Realistic noise signal.
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # Validate baseline-drift kwargs at the public-API entry point — the
+    # guarded ``if baseline_drift_rms_uv > 0`` branch below would
+    # otherwise let bad values pass through silently. Each error names
+    # the offending kwarg so callers (and tests) can pattern-match.
+    if baseline_drift_rms_uv < 0:
+        raise ValueError(
+            f"baseline_drift_rms_uv must be >= 0, got {baseline_drift_rms_uv!r}"
+        )
+    if baseline_drift_alpha <= 0:
+        raise ValueError(
+            f"baseline_drift_alpha must be > 0, got {baseline_drift_alpha!r}"
+        )
+    if baseline_drift_high_hz <= 0:
+        raise ValueError(
+            f"baseline_drift_high_hz must be > 0, got {baseline_drift_high_hz!r}"
+        )
+    if baseline_drift_high_hz >= fs_hz / 2.0:
+        raise ValueError(
+            f"baseline_drift_high_hz must be < Nyquist (fs_hz / 2 = "
+            f"{fs_hz / 2.0:.3f}), got {baseline_drift_high_hz!r}"
+        )
+    if baseline_drift_low_hz is not None:
+        if baseline_drift_low_hz <= 0:
+            raise ValueError(
+                f"baseline_drift_low_hz must be > 0, got "
+                f"{baseline_drift_low_hz!r}"
+            )
+        if baseline_drift_low_hz >= baseline_drift_high_hz:
+            raise ValueError(
+                f"baseline_drift_low_hz ({baseline_drift_low_hz!r}) must be "
+                f"< baseline_drift_high_hz ({baseline_drift_high_hz!r})"
+            )
+
+    # 1. Colored noise base
+    noise = _colored_noise(n_samples, fs_hz, spectral_slope, rng)
+
+    # 2. EMG-band spectral emphasis (replaces simple bandpass)
+    noise = _emg_band_shape(noise, fs_hz, peak_hz=peak_hz)
+
+    # 3. Heavy tails (conservative)
+    noise = _make_heavy_tailed(noise, excess_kurtosis, rng)
+
+    # 4. Analog high-pass filter — mimics the amplifier's front-end HPF
+    # (Quattrocento: 10 Hz, Trigno: 20 Hz, clinical: 2 Hz). Without this
+    # stage the broadband base extends flat down to DC, while real
+    # recordings show a clear corner below 10-20 Hz. Applied before
+    # rescaling so the post-HPF RMS hits the target exactly.
+    if analog_hpf_hz > 0:
+        sos_hpf = sig.butter(2, analog_hpf_hz, fs=fs_hz, btype="high", output="sos")
+        noise = sig.sosfiltfilt(sos_hpf, noise)
+
+    # 5. Scale the BROADBAND base to ``noise_rms`` BEFORE adding powerline
+    # interference. ``noise_rms`` is the device's broadband floor RMS;
+    # powerline is an additional environmental layer that adds power on
+    # top — it should not eat the broadband budget. After this step,
+    # ``noise.std() == noise_rms`` so ``_add_powerline`` will use the
+    # broadband floor as the reference for ``base = amplitude * noise.std()``.
+    current_rms = np.sqrt(np.mean(noise**2))
+    if current_rms > 0:
+        noise *= noise_rms / current_rms
+
+    # 5b. Baseline drift — slow low-frequency wander attributed to
+    # the electrode/interface (Huigen 2002; Gondran 1996). Additive
+    # in absolute units, post-HPF (i.e., what actually survives into
+    # the recorded signal). Off by default.
+    if baseline_drift_rms_uv > 0:
+        # Resolve ``low_hz=None`` to the lowest nonzero FFT bin so the
+        # drift band always has at least one sample. If the recording
+        # is so short that even this bin is above ``high_hz``, raise
+        # rather than silently emit zeros.
+        n_fft = n_samples + (n_samples % 2)
+        lowest_nonzero = float(fs_hz / n_fft)
+        drift_low_hz = (
+            lowest_nonzero
+            if baseline_drift_low_hz is None
+            else float(baseline_drift_low_hz)
+        )
+        if drift_low_hz > baseline_drift_high_hz:
+            raise ValueError(
+                "baseline drift band is empty: lowest available FFT bin "
+                f"({lowest_nonzero:.4f} Hz) exceeds baseline_drift_high_hz "
+                f"({baseline_drift_high_hz}). Increase n_samples or "
+                "baseline_drift_high_hz."
+            )
+        noise = noise + _baseline_drift(
+            n_samples, fs_hz,
+            target_rms=baseline_drift_rms_uv,
+            alpha=baseline_drift_alpha,
+            low_hz=drift_low_hz,
+            high_hz=baseline_drift_high_hz,
+            rng=rng,
+        )
+
+    # 6. Powerline interference (fundamental + harmonics, additive on top
+    #    of the device colour; harmonics 50/100/150/200/250 Hz by default).
+    if powerline_hz > 0 and powerline_amplitude > 0:
+        noise = _add_powerline(
+            noise, fs_hz, powerline_hz, powerline_amplitude, rng,
+            harmonic_ratios=powerline_harmonic_ratios,
+            frequency_drift_hz=powerline_frequency_drift_hz,
+            amplitude_modulation_depth=powerline_amplitude_modulation_depth,
+        )
+
+    return noise
+
+
+def add_realistic_noise(
+    clean_emg: np.ndarray,
+    fs_hz: float,
+    target_snr_db: float = 20.0,
+    *,
+    noise_rms: float | None = None,
+    spectral_slope: float = -0.5,
+    excess_kurtosis: float = 3.0,
+    powerline_hz: float = 50.0,
+    powerline_amplitude: float = 0.1,
+    powerline_harmonic_ratios: list[float] | None = None,
+    powerline_frequency_drift_hz: float = 0.3,
+    powerline_amplitude_modulation_depth: float = 0.15,
+    peak_hz: float = 1000.0,
+    analog_hpf_hz: float = 10.0,
+    baseline_drift_rms_uv: float = 0.0,
+    baseline_drift_alpha: float = 1.75,
+    baseline_drift_low_hz: float | None = None,
+    baseline_drift_high_hz: float = 1.0,
+    rng: np.random.Generator | None = None,
+) -> np.ndarray:
+    """Add realistic noise to a clean EMG signal.
+
+    The noise floor is constant (signal-independent), matching real
+    intramuscular EMG recordings.  The amplitude is determined either
+    by ``target_snr_db`` (auto-calibrated from the signal) or by an
+    explicit ``noise_rms``.
+
+    When using ``target_snr_db``, the noise RMS is computed from the
+    signal's overall RMS:
+
+        noise_rms = signal_rms / 10^(target_snr_db / 20)
+
+    This value is then applied as a CONSTANT floor — same amplitude
+    during rest and contraction.  During active periods the effective
+    SNR matches ``target_snr_db``; during rest the noise dominates
+    (matching real recordings).
+
+    Parameters
+    ----------
+    clean_emg : ndarray, shape (n_samples,) or (n_samples, n_channels)
+        Clean EMG signal.
+    fs_hz : float
+        Sampling rate (Hz).
+    target_snr_db : float, default 20.0
+        Target SNR during active contraction.  Used to auto-compute
+        noise_rms from the signal.  Ignored if noise_rms is provided.
+    noise_rms : float or None
+        Explicit noise floor RMS.  If provided, overrides target_snr_db.
+        Must be in the same units as the EMG signal.
+    spectral_slope : float, default -0.5
+        PSD slope.  See generate_realistic_noise().
+    excess_kurtosis : float, default 3.0
+        Target excess kurtosis.
+    powerline_hz : float, default 50.0
+        Powerline frequency.  Set to 0 to disable.
+    powerline_amplitude : float, default 0.1
+        Powerline amplitude as fraction of noise RMS.
+    powerline_harmonic_ratios : list of float, optional
+        Per-harmonic amplitude ratios relative to the fundamental.
+    powerline_frequency_drift_hz : float, default 0.3
+        STD of the slow drift of the mains instantaneous frequency.
+        See :func:`generate_realistic_noise`.
+    powerline_amplitude_modulation_depth : float, default 0.15
+        Fractional AM depth on the powerline carriers. See
+        :func:`generate_realistic_noise`.
+    peak_hz : float, default 750.0
+        Center of EMG-band spectral emphasis.
+    analog_hpf_hz : float, default 10.0
+        Analog HPF cutoff applied before powerline is mixed in.
+    baseline_drift_rms_uv : float, default 0.0
+        Target RMS of the band-limited 1/f^α drift (off by default).
+        See :func:`generate_realistic_noise` for the paper-constrained
+        spectral form and calibration guidance. Each channel receives
+        an independent drift realisation; common-mode array drift
+        is not modelled.
+    baseline_drift_alpha : float, default 1.75
+        Drift PSD slope α. Midpoint of the [1.5, 2.0] electrode-noise
+        regime (Huigen 2002, Gondran 1996).
+    baseline_drift_low_hz : float or None, default None
+        Lower edge of the drift band (lowest nonzero FFT bin when None).
+    baseline_drift_high_hz : float, default 1.0
+        Upper edge of the drift band. Default scopes the knob to
+        sub-1 Hz baseline wander; broadband movement artifacts are
+        out of scope.
+    rng : np.random.Generator or None
+        Random generator.
+
+    Returns
+    -------
+    ndarray
+        Noisy EMG signal (same shape as input).
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+
+    emg = np.asarray(clean_emg)
+    is_1d = emg.ndim == 1
+
+    if is_1d:
+        emg = emg[:, np.newaxis]
+
+    n_samples, n_channels = emg.shape
+
+    # Compute noise RMS from signal if not explicitly provided
+    if noise_rms is None:
+        signal_rms = np.sqrt(np.mean(emg**2))
+        if signal_rms > 0:
+            noise_rms = signal_rms / (10 ** (target_snr_db / 20))
+        else:
+            noise_rms = 1e-6  # fallback for silent signal
+
+    noisy = emg.copy()
+
+    for ch in range(n_channels):
+        noise = generate_realistic_noise(
+            n_samples,
+            fs_hz,
+            noise_rms,
+            spectral_slope=spectral_slope,
+            excess_kurtosis=excess_kurtosis,
+            powerline_hz=powerline_hz,
+            powerline_amplitude=powerline_amplitude,
+            powerline_harmonic_ratios=powerline_harmonic_ratios,
+            powerline_frequency_drift_hz=powerline_frequency_drift_hz,
+            powerline_amplitude_modulation_depth=powerline_amplitude_modulation_depth,
+            peak_hz=peak_hz,
+            analog_hpf_hz=analog_hpf_hz,
+            baseline_drift_rms_uv=baseline_drift_rms_uv,
+            baseline_drift_alpha=baseline_drift_alpha,
+            baseline_drift_low_hz=baseline_drift_low_hz,
+            baseline_drift_high_hz=baseline_drift_high_hz,
+            rng=rng,
+        )
+        noisy[:, ch] += noise
+
+    if is_1d:
+        noisy = noisy[:, 0]
+
+    return noisy
+
+
+def estimate_noise_rms_from_recording(
+    emg: np.ndarray,
+    fs_hz: float,
+    *,
+    highpass_hz: float = 2000.0,
+) -> float:
+    """Estimate the noise floor RMS from a real recording.
+
+    Uses the high-frequency content (above ``highpass_hz``) as a proxy
+    for the noise floor, since real MU activity is mostly below 2 kHz.
+
+    Parameters
+    ----------
+    emg : ndarray, shape (n_samples,) or (n_samples, n_channels)
+        Raw EMG recording (can include both rest and active periods).
+    fs_hz : float
+        Sampling rate.
+    highpass_hz : float, default 2000.0
+        Frequency above which content is assumed to be noise.
+
+    Returns
+    -------
+    float
+        Estimated noise RMS (averaged across channels if multi-channel).
+    """
+    emg = np.asarray(emg)
+    if emg.ndim == 1:
+        emg = emg[:, np.newaxis]
+
+    sos = sig.butter(4, highpass_hz, fs=fs_hz, btype="high", output="sos")
+    rms_values = []
+    for ch in range(emg.shape[1]):
+        hf = sig.sosfilt(sos, emg[:, ch])
+        rms_values.append(np.sqrt(np.mean(hf**2)))
+
+    return float(np.mean(rms_values))
+
+
+def _notch_powerline(
+    x: np.ndarray, fs_hz: float, powerline_hz: float, q: float = 30.0
+) -> np.ndarray:
+    """Cascade of IIR notches at the powerline fundamental + harmonics.
+
+    Strips 50/60 Hz and its 2nd–5th harmonics from a 1-D trace using
+    zero-phase filtering, leaving the broadband colour intact. Same
+    convention as the real-signal preprocessing used to derive the
+    default Quattrocento profile.
+    """
+    out = x.astype(np.float64, copy=True)
+    nyq = fs_hz / 2.0
+    for k in range(1, 6):
+        f = powerline_hz * k
+        if f >= nyq or f <= 0:
+            continue
+        b, a = sig.iirnotch(f, q, fs_hz)
+        out = sig.filtfilt(b, a, out)
+    return out
+
+
+def calibrate_realistic_noise_profile(
+    real_signal_uv: np.ndarray,
+    fs_hz: float,
+    *,
+    rest_mask: np.ndarray | None = None,
+    powerline_hz: float = 50.0,
+    notch_q: float = 30.0,
+    hf_floor_hz: float = 2000.0,
+    welch_nperseg: int | None = None,
+) -> dict:
+    """Estimate realistic-noise parameters from a real iEMG recording.
+
+    Reproduces the calibration pipeline used to derive the default profile:
+
+    1. Apply cascaded IIR notches at the powerline fundamental +
+       harmonics (50/100/150/200/250 Hz for EU; 60/120/180/240 for US).
+    2. Isolate a pure-noise residual:
+
+       * if ``rest_mask`` is provided, take only the samples where the
+         subject was at rest;
+       * otherwise high-pass the trace above ``hf_floor_hz`` (default
+         2 kHz) — a fallback that exploits the empirical fact
+         that real iEMG noise is signal-independent.
+
+    3. Compute the Welch PSD of the residual; fit the spectral slope
+       above the in-band peak and locate ``peak_hz``.
+    4. Standardise the residual and compute its excess kurtosis.
+    5. Recover the powerline amplitude by comparing pre-notch vs
+       post-notch RMS in a ±1 Hz band around each harmonic.
+
+    The output dict is shaped to be unpacked straight into
+    :func:`generate_realistic_noise` /
+    :meth:`myogen.simulator.IntramuscularEMG.add_noise` so the simulator
+    will reproduce the same noise statistics as the real recording.
+
+    Parameters
+    ----------
+    real_signal_uv : ndarray, shape (n_samples,) or (n_samples, n_channels)
+        Raw iEMG, **in µV**. Multi-channel arrays are flattened across
+        channels for the statistics (each channel contributes equally).
+    fs_hz : float
+        Sampling rate of the recording.
+    rest_mask : ndarray of bool, optional
+        Per-sample mask, same length as the time axis. ``True`` marks
+        rest samples used for the noise statistics. If ``None``, the
+        high-frequency fallback is used (samples above ``hf_floor_hz``).
+    powerline_hz : float, default 50.0
+        Powerline frequency. Use ``60.0`` for North-American grids.
+    notch_q : float, default 30.0
+        Quality factor of the IIR notches.
+    hf_floor_hz : float, default 2000.0
+        High-pass cutoff for the HF-fallback noise estimate (used when
+        ``rest_mask`` is ``None``). Should sit above the MUAP band.
+    welch_nperseg : int, optional
+        Welch segment length. ``None`` picks ``min(len(residual), 4 *
+        int(fs_hz))`` so we get ~0.25 Hz frequency resolution.
+
+    Returns
+    -------
+    dict
+        Keys ready to splat into :func:`generate_realistic_noise`:
+
+        * ``noise_floor_uv`` — RMS of the noise residual (µV).
+        * ``spectral_slope`` — PSD slope in log-log space above the peak.
+        * ``peak_hz`` — frequency of the EMG-band emphasis (Hz).
+        * ``excess_kurtosis`` — Fisher kurtosis of the standardised residual.
+        * ``powerline_hz`` — echo of the input (Hz).
+        * ``powerline_amplitude`` — fundamental amplitude as a fraction
+          of ``noise_floor_uv``.
+        * ``powerline_harmonic_ratios`` — measured per-harmonic amplitude
+          ratios relative to the fundamental (length 5).
+    """
+    sig_arr = np.asarray(real_signal_uv, dtype=np.float64)
+    if sig_arr.ndim == 1:
+        sig_arr = sig_arr[:, np.newaxis]
+    n_samples, n_channels = sig_arr.shape
+
+    if rest_mask is not None:
+        rest_mask = np.asarray(rest_mask, dtype=bool)
+        if rest_mask.shape != (n_samples,):
+            raise ValueError(
+                f"rest_mask shape {rest_mask.shape} does not match the "
+                f"time axis length {n_samples}"
+            )
+        if not rest_mask.any():
+            raise ValueError("rest_mask must contain at least one True sample")
+
+    # 1. Notched copy (broadband-only signal, no powerline content).
+    notched = np.empty_like(sig_arr)
+    for ch in range(n_channels):
+        notched[:, ch] = _notch_powerline(
+            sig_arr[:, ch], fs_hz, powerline_hz, q=notch_q
+        )
+
+    # 2. Build the noise residual per channel.
+    if rest_mask is not None:
+        # Take only rest samples, but apply on the *notched* trace so
+        # the residual is free of powerline content.
+        residual_per_ch = [notched[rest_mask, ch] for ch in range(n_channels)]
+    else:
+        # HF fallback: high-pass above hf_floor_hz, full duration.
+        sos_hp = sig.butter(4, hf_floor_hz, fs=fs_hz, btype="high", output="sos")
+        residual_per_ch = [
+            sig.sosfiltfilt(sos_hp, notched[:, ch]) for ch in range(n_channels)
+        ]
+
+    # 3. ``noise_floor_uv`` is deliberately derived from the integrated
+    # median PSD rather than from per-channel rest RMS: real-rest RMS
+    # includes sporadic artefacts (breathing, micro-MUs) that the median
+    # Welch PSD downstream suppresses, which keeps the calibration and the
+    # overlay on the same statistic.
+
+    # 4. Per-channel Welch PSDs averaged before slope/peak extraction —
+    # pooling residuals across channels with different scales / artifact
+    # loads distorts the pooled distribution and miscomputes statistics
+    # like kurtosis. Per-channel + median aggregation is robust against
+    # a single bad channel.
+    nperseg = welch_nperseg
+    if nperseg is None:
+        nperseg = min(min(len(r) for r in residual_per_ch), int(4 * fs_hz))
+    nperseg = max(64, nperseg)
+    psd_stack = []
+    for r in residual_per_ch:
+        freqs, psd_ch = sig.welch(
+            r,
+            fs=fs_hz,
+            nperseg=nperseg,
+            noverlap=int(nperseg * 0.75),
+            average="median",
+        )
+        psd_stack.append(psd_ch)
+    psd = np.median(np.stack(psd_stack, axis=0), axis=0)
+
+    # Noise floor = sqrt of total median PSD power. By construction,
+    # generating a noise trace with this RMS will produce a Welch
+    # median PSD whose integral matches the real one.
+    df_psd = float(freqs[1] - freqs[0])
+    noise_floor_uv = float(np.sqrt(max(np.sum(psd) * df_psd, 0.0)))
+
+    band_lo, band_hi = 100.0, 2000.0
+    in_band = (freqs >= band_lo) & (freqs <= band_hi)
+
+    def _measured_slope(spectrum: np.ndarray, freqs_axis: np.ndarray, peak_hz_local: float) -> float:
+        """Linear fit of log10(PSD) above the peak."""
+        fit_lo_l = peak_hz_local * 1.2
+        fit_hi_l = fs_hz / 2.0 * 0.9
+        fmask = (freqs_axis >= fit_lo_l) & (freqs_axis <= fit_hi_l) & (spectrum > 0)
+        if np.count_nonzero(fmask) < 4:
+            return float("nan")
+        s, _ = np.polyfit(
+            np.log10(freqs_axis[fmask]), np.log10(spectrum[fmask]), 1
+        )
+        return float(s)
+
+    if not np.any(in_band):
+        peak_hz = 1000.0
+        spectral_slope = -0.5
+    else:
+        peak_idx_local = int(np.argmax(psd[in_band]))
+        peak_hz = float(freqs[in_band][peak_idx_local])
+        target_slope = _measured_slope(psd, freqs, peak_hz)
+        if not np.isfinite(target_slope):
+            spectral_slope = -0.5
+        else:
+            # The `spectral_slope` knob feeds the colored-noise base
+            # BEFORE _emg_band_shape blends in an additional bandpass
+            # emphasis, so the input slope is not the output slope. We
+            # back-solve by running a couple of probe simulations: fit
+            # a linear model output_slope ≈ a * input_slope + b on two
+            # probe runs, then invert.
+            probe_n = min(int(fs_hz * 8), n_samples)  # 8 s probes
+            probe_rng = np.random.default_rng(0)
+            probe_in = [-0.2, -1.2]
+            probe_out: list[float] = []
+            for slope_in in probe_in:
+                probe_noise = generate_realistic_noise(
+                    probe_n,
+                    fs_hz,
+                    noise_rms=1.0,
+                    spectral_slope=slope_in,
+                    excess_kurtosis=0.0,
+                    powerline_hz=0.0,
+                    powerline_amplitude=0.0,
+                    peak_hz=peak_hz,
+                    rng=probe_rng,
+                )
+                f_p, psd_p = sig.welch(
+                    probe_noise,
+                    fs=fs_hz,
+                    nperseg=min(probe_n, int(2 * fs_hz)),
+                    noverlap=int(min(probe_n, int(2 * fs_hz)) * 0.75),
+                    average="median",
+                )
+                probe_out.append(_measured_slope(psd_p, f_p, peak_hz))
+            if all(np.isfinite(probe_out)):
+                a = (probe_out[1] - probe_out[0]) / (probe_in[1] - probe_in[0])
+                b = probe_out[0] - a * probe_in[0]
+                if abs(a) > 1e-6:
+                    spectral_slope = float((target_slope - b) / a)
+                else:
+                    spectral_slope = float(target_slope)
+            else:
+                spectral_slope = float(target_slope)
+
+    # 5b. Analog HPF corner — detect from the low-frequency PSD shape.
+    # Estimate an in-band reference level (median PSD in 30 Hz-min(peak/2,
+    # 200 Hz)), then walk from DC upward to the first bin where the PSD
+    # crosses (reference − 3 dB). That bin is the −3 dB corner frequency
+    # of whatever HPF (analog + digital) shaped the input.
+    ref_lo, ref_hi = 30.0, min(max(peak_hz / 2.0, 60.0), 200.0)
+    ref_mask = (freqs >= ref_lo) & (freqs <= ref_hi) & (psd > 0)
+    if np.any(ref_mask):
+        ref_psd = float(np.median(psd[ref_mask]))
+        threshold = ref_psd * 0.5  # -3 dB in power
+        rising_mask = (freqs > 0) & (freqs < ref_lo) & (psd >= threshold)
+        if rising_mask.any():
+            analog_hpf_hz = float(freqs[rising_mask][0])
+        else:
+            analog_hpf_hz = 10.0
+    else:
+        analog_hpf_hz = 10.0
+
+    # 5. Excess kurtosis per channel → median (robust to outlier channels).
+    kurt_per_ch = []
+    for r in residual_per_ch:
+        centered = r - np.mean(r)
+        std = np.std(centered)
+        if std > 0:
+            m4 = np.mean(centered ** 4) / (std ** 4)
+            kurt_per_ch.append(float(m4 - 3.0))
+    excess_kurtosis = float(np.median(kurt_per_ch)) if kurt_per_ch else 0.0
+
+    # 6. Powerline amplitude + harmonic ratios — directly from the
+    # *un-notched* signal's PSD. For each harmonic, measure the excess
+    # power inside a ±2 Hz band centred on the line over the broadband
+    # floor estimated from nearby frequencies. Excess power equates to
+    # ``amplitude² / 2`` for a sinusoid, so amplitude = sqrt(2 * excess).
+    # This avoids the bias from the iirnotch's finite passband width
+    # that the previous variance-difference approach inherited.
+    raw_psd_stack = []
+    for ch in range(n_channels):
+        f_raw, p_raw_ch = sig.welch(
+            sig_arr[:, ch],
+            fs=fs_hz,
+            nperseg=nperseg,
+            noverlap=int(nperseg * 0.75),
+            average="median",
+        )
+        raw_psd_stack.append(p_raw_ch)
+    raw_psd = np.median(np.stack(raw_psd_stack, axis=0), axis=0)
+    df_raw = float(f_raw[1] - f_raw[0])
+
+    harmonic_amps = []
+    nyq = fs_hz / 2.0
+    for k in range(1, 6):
+        f = powerline_hz * k
+        if f >= nyq:
+            harmonic_amps.append(0.0)
+            continue
+        peak_lo, peak_hi = f - 2.0, f + 2.0
+        peak_mask = (f_raw >= peak_lo) & (f_raw <= peak_hi)
+        peak_power = float(np.sum(raw_psd[peak_mask]) * df_raw)
+        # Neighbouring band for the broadband floor (exclude the peak
+        # window itself).
+        nbr_lo1, nbr_hi1 = max(f - 8.0, 0.5), f - 2.0
+        nbr_lo2, nbr_hi2 = f + 2.0, min(f + 8.0, nyq * 0.999)
+        nbr_mask = (
+            ((f_raw >= nbr_lo1) & (f_raw <= nbr_hi1))
+            | ((f_raw >= nbr_lo2) & (f_raw <= nbr_hi2))
+        )
+        if not np.any(nbr_mask):
+            harmonic_amps.append(0.0)
+            continue
+        floor_density = float(np.median(raw_psd[nbr_mask]))
+        floor_in_peak_band = floor_density * (peak_hi - peak_lo)
+        excess = max(peak_power - floor_in_peak_band, 0.0)
+        harmonic_amps.append(float(np.sqrt(2.0 * excess)))
+    fundamental_amp = harmonic_amps[0]
+    if fundamental_amp > 0 and noise_floor_uv > 0:
+        powerline_amplitude = float(fundamental_amp / noise_floor_uv)
+        powerline_harmonic_ratios = [
+            float(a / fundamental_amp) for a in harmonic_amps
+        ]
+    else:
+        powerline_amplitude = 0.0
+        powerline_harmonic_ratios = [1.0, 0.0, 0.0, 0.0, 0.0]
+
+    return {
+        "noise_floor_uv": noise_floor_uv,
+        "spectral_slope": spectral_slope,
+        "peak_hz": peak_hz,
+        "excess_kurtosis": excess_kurtosis,
+        "powerline_hz": float(powerline_hz),
+        "powerline_amplitude": powerline_amplitude,
+        "powerline_harmonic_ratios": powerline_harmonic_ratios,
+        "analog_hpf_hz": float(analog_hpf_hz),
+    }
+
+
+def calibrate_baseline_drift_profile(
+    real_signal_uv: np.ndarray,
+    fs_hz: float,
+    *,
+    rest_mask: np.ndarray | None = None,
+    band: tuple[float | None, float] = (None, 1.0),
+) -> dict:
+    """Estimate baseline-drift parameters from a real recording.
+
+    Fits the band-limited 1/f^α drift model
+    (see :func:`generate_realistic_noise`) to the low-frequency PSD
+    of ``real_signal_uv`` over ``band = (low_hz, high_hz)``. Returns
+    a dict with the four ``baseline_drift_*`` kwargs that
+    :func:`generate_realistic_noise` and downstream APIs accept, so
+    the user can splat it directly:
+
+        >>> profile = calibrate_baseline_drift_profile(real_uv, fs_hz)
+        >>> generate_realistic_noise(n, fs_hz, noise_rms=5.0, **profile)
+
+    The amplitude is returned in the **same units as the input
+    signal** (µV when the input is in µV); the function does *not*
+    standardise the channels because that would erase the scale.
+
+    .. note::
+       The model's spectral form (PSD ∝ 1/f^α over a bounded band)
+       is paper-constrained for electrode/interface noise (Huigen
+       2002, Gondran 1996). The fitted parameters become validated
+       only when this calibration is run on real recordings — they
+       are not pre-baked physiological constants.
+
+    Parameters
+    ----------
+    real_signal_uv : ndarray, shape (n_samples,) or (n_samples, n_channels)
+        Raw real recording in µV. Multi-channel inputs are aggregated
+        via a median Welch PSD (robust to one bad channel).
+    fs_hz : float
+        Sampling rate.
+    rest_mask : ndarray of bool, optional
+        Per-sample boolean mask; ``True`` marks rest samples to use
+        for the fit. ``None`` uses the full trace.
+    band : tuple of (float or None, float), default (None, 1.0)
+        Fit band. The lower bound defaults to the lowest nonzero
+        Welch bin available given the chosen segment length; the
+        upper bound defaults to 1 Hz (sub-1 Hz baseline wander per
+        Boyer 2023, DOI 10.3390/s23062927).
+
+    Returns
+    -------
+    dict
+        ``{"baseline_drift_rms_uv", "baseline_drift_alpha",
+        "baseline_drift_low_hz", "baseline_drift_high_hz"}``.
+    """
+    band_low_arg, band_high = band
+    if band_high <= 0:
+        raise ValueError(f"band[1] (high_hz) must be > 0, got {band_high!r}")
+    if band_low_arg is not None and band_low_arg <= 0:
+        raise ValueError(f"band[0] (low_hz) must be > 0 or None, got {band_low_arg!r}")
+    if band_low_arg is not None and band_low_arg >= band_high:
+        raise ValueError(
+            f"band[0] ({band_low_arg!r}) must be < band[1] ({band_high!r})"
+        )
+
+    sig_arr = np.asarray(real_signal_uv, dtype=np.float64)
+    if sig_arr.ndim == 1:
+        sig_arr = sig_arr[:, np.newaxis]
+    n_total, n_channels = sig_arr.shape
+
+    if rest_mask is not None:
+        rest_mask = np.asarray(rest_mask, dtype=bool)
+        if rest_mask.shape != (n_total,):
+            raise ValueError(
+                f"rest_mask shape {rest_mask.shape} does not match the "
+                f"time axis length {n_total}"
+            )
+        if not rest_mask.any():
+            raise ValueError("rest_mask must contain at least one True sample")
+        per_ch = [sig_arr[rest_mask, ch] for ch in range(n_channels)]
+    else:
+        per_ch = [sig_arr[:, ch] for ch in range(n_channels)]
+
+    n_rest = min(len(x) for x in per_ch)
+    if n_rest < 16:
+        raise ValueError(
+            f"need at least 16 samples per channel after the rest mask, got {n_rest}"
+        )
+
+    # Aim for ~0.125 Hz frequency resolution at the default sub-1 Hz
+    # band; clamp to what the data supports. If the user supplied a
+    # tighter ``band_low``, expand the segment so several bins land
+    # above it when the recording is long enough.
+    target_nperseg = max(int(8 * fs_hz), 1024)
+    if band_low_arg is not None:
+        target_nperseg = max(target_nperseg, int(4.0 * fs_hz / band_low_arg))
+    nperseg = min(n_rest, target_nperseg)
+    nperseg = max(64, nperseg)
+    noverlap = int(nperseg * 0.5)
+
+    psd_stack = []
+    for r in per_ch:
+        freqs_ref, psd_ch = sig.welch(
+            r, fs=fs_hz, nperseg=nperseg, noverlap=noverlap, average="median",
+        )
+        psd_stack.append(psd_ch)
+    psd = np.median(np.stack(psd_stack, axis=0), axis=0)
+    df = float(freqs_ref[1] - freqs_ref[0])
+
+    if band_low_arg is None:
+        band_low = float(freqs_ref[1])  # lowest nonzero Welch bin
+    else:
+        band_low = float(band_low_arg)
+    if band_high >= fs_hz / 2.0:
+        raise ValueError(
+            f"band[1] ({band_high!r}) must be < Nyquist (fs_hz/2 = "
+            f"{fs_hz / 2.0:.3f})"
+        )
+    if band_low >= band_high:
+        raise ValueError(
+            f"resolved band_low ({band_low:.4f} Hz) >= band_high "
+            f"({band_high:.4f} Hz). Recording may be too short for "
+            "the requested band."
+        )
+
+    fit_mask = (freqs_ref >= band_low) & (freqs_ref <= band_high) & (psd > 0)
+    if np.count_nonzero(fit_mask) < 3:
+        raise ValueError(
+            "fewer than 3 positive PSD bins in the calibration band; "
+            "increase the recording length or widen the band."
+        )
+
+    # alpha = -slope of log10(PSD) vs log10(f) over the band.
+    log_f = np.log10(freqs_ref[fit_mask])
+    log_p = np.log10(psd[fit_mask])
+    slope, _ = np.polyfit(log_f, log_p, 1)
+    alpha = float(-slope)
+
+    # RMS = sqrt(sum(PSD * df)) within the band, preserving µV units.
+    band_power = float(np.sum(psd[fit_mask]) * df)
+    rms_uv = float(np.sqrt(max(band_power, 0.0)))
+
+    return {
+        "baseline_drift_rms_uv": rms_uv,
+        "baseline_drift_alpha": alpha,
+        "baseline_drift_low_hz": band_low,
+        "baseline_drift_high_hz": float(band_high),
+    }
+
+
+def tune_noise_profile_with_optuna(
+    real_signal_uv: np.ndarray,
+    fs_hz: float,
+    initial_profile: dict,
+    *,
+    rest_mask: np.ndarray | None = None,
+    n_trials: int = 100,
+    psd_freq_band_hz: tuple[float, float] = (2.0, 2000.0),
+    seed: int = 0,
+    show_progress_bar: bool = False,
+) -> dict:
+    """Refine a noise profile with Optuna to minimise PSD distance vs real.
+
+    Closed-form calibration (:func:`calibrate_realistic_noise_profile`)
+    matches the first few moments and spectral summary statistics but
+    can leave residual shape mismatch — most visibly the low-frequency
+    rolloff curvature and the line-peak shape. This function takes the
+    closed-form profile as a starting point and runs an Optuna TPE
+    search around it, minimising the **L1 distance between log-PSDs**
+    of the simulated and real signals in ``psd_freq_band_hz``.
+
+    Cost is fast: each trial generates ~30 s of simulated noise and
+    computes one Welch PSD. 100 trials ≈ a few seconds on a laptop.
+
+    Parameters
+    ----------
+    real_signal_uv : ndarray, shape (n_samples,) or (n_samples, n_channels)
+        Real iEMG signal in µV (multi-channel will be aggregated as
+        median PSD across channels).
+    fs_hz : float
+        Sampling rate.
+    initial_profile : dict
+        Output of :func:`calibrate_realistic_noise_profile`. Used as
+        starting point + to define the search bounds.
+    rest_mask : ndarray of bool, optional
+        Per-sample rest mask. If provided, the reference PSD is built
+        from the rest samples only — same convention as the closed-form
+        calibrator.
+    n_trials : int, default 100
+        Number of Optuna trials.
+    psd_freq_band_hz : tuple of float, default (2.0, 2000.0)
+        Frequency band over which the log-PSD distance is computed.
+        Restrict to the band you actually care about — typically the
+        EMG band, leaving anti-alias rolloff out.
+    seed : int, default 0
+        Optuna sampler seed.
+    show_progress_bar : bool, default False
+        Pass through to ``optuna.study.optimize`` for a tqdm bar.
+
+    Returns
+    -------
+    dict
+        Tuned profile in the same shape as ``initial_profile``, with
+        an extra key ``"_optuna_loss"`` reporting the final L1 log-PSD
+        distance.
+    """
+    import optuna
+
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+    # 1. Build the real reference PSD using the same conventions as the
+    # calibrator (rest-mask + notch + median across channels).
+    sig_arr = np.asarray(real_signal_uv, dtype=np.float64)
+    if sig_arr.ndim == 1:
+        sig_arr = sig_arr[:, np.newaxis]
+    n_samples, n_channels = sig_arr.shape
+
+    powerline_hz = float(initial_profile["powerline_hz"])
+    notched = np.empty_like(sig_arr)
+    for ch in range(n_channels):
+        notched[:, ch] = _notch_powerline(sig_arr[:, ch], fs_hz, powerline_hz)
+
+    if rest_mask is not None:
+        rest_mask = np.asarray(rest_mask, dtype=bool)
+        residual_per_ch = [notched[rest_mask, ch] for ch in range(n_channels)]
+    else:
+        sos_hp = sig.butter(4, 2000.0, fs=fs_hz, btype="high", output="sos")
+        residual_per_ch = [
+            sig.sosfiltfilt(sos_hp, notched[:, ch]) for ch in range(n_channels)
+        ]
+
+    nperseg = min(min(len(r) for r in residual_per_ch), int(4 * fs_hz))
+    nperseg = max(64, nperseg)
+    noverlap = int(nperseg * 0.75)
+
+    # Frequency axis for the band mask — identical grid for every Welch
+    # PSD computed below, so one call on the first residual suffices.
+    freqs_ref = sig.welch(
+        residual_per_ch[0], fs=fs_hz, nperseg=nperseg, noverlap=noverlap,
+        average="median",
+    )[0]
+
+    # Reference PSD on the UN-notched signal, so the powerline lines
+    # contribute to the fit during the powerline-amplitude trials.
+    raw_stack = []
+    for ch in range(n_channels):
+        if rest_mask is not None:
+            r = sig_arr[rest_mask, ch]
+        else:
+            r = sig_arr[:, ch]
+        _, p = sig.welch(
+            r, fs=fs_hz, nperseg=nperseg, noverlap=noverlap, average="median"
+        )
+        raw_stack.append(p)
+    raw_real_psd = np.median(np.stack(raw_stack, axis=0), axis=0)
+    log_real_raw = np.log10(np.maximum(raw_real_psd, 1e-30))
+
+    band_mask = (freqs_ref >= psd_freq_band_hz[0]) & (freqs_ref <= psd_freq_band_hz[1])
+
+    # 2. Search bounds — narrow ranges around the initial profile.
+    init = initial_profile
+    sim_len = int(min(n_samples, fs_hz * 30))  # 30 s probes — fast & enough resolution
+    base_rng = np.random.default_rng(seed)
+
+    def _objective(trial: "optuna.trial.Trial") -> float:
+        noise_floor_uv = trial.suggest_float(
+            "noise_floor_uv",
+            max(init["noise_floor_uv"] * 0.5, 0.1),
+            init["noise_floor_uv"] * 2.0,
+        )
+        spectral_slope = trial.suggest_float(
+            "spectral_slope",
+            init["spectral_slope"] - 0.8,
+            init["spectral_slope"] + 0.8,
+        )
+        peak_hz = trial.suggest_float(
+            "peak_hz",
+            max(init["peak_hz"] * 0.5, 100.0),
+            min(init["peak_hz"] * 2.0, fs_hz / 2.0 * 0.9),
+        )
+        excess_kurtosis = trial.suggest_float(
+            "excess_kurtosis",
+            max(init["excess_kurtosis"] - 1.5, 0.0),
+            init["excess_kurtosis"] + 3.0,
+        )
+        powerline_amplitude = trial.suggest_float(
+            "powerline_amplitude",
+            max(init["powerline_amplitude"] * 0.3, 0.0),
+            init["powerline_amplitude"] * 3.0 + 0.05,
+        )
+        analog_hpf_hz = trial.suggest_float(
+            "analog_hpf_hz",
+            max(init["analog_hpf_hz"] * 0.3, 1.0),
+            init["analog_hpf_hz"] * 3.0,
+        )
+
+        # Fixed: harmonic ratios + powerline_hz (these are well-determined).
+        trial_noise = generate_realistic_noise(
+            sim_len,
+            fs_hz,
+            noise_rms=noise_floor_uv,
+            spectral_slope=spectral_slope,
+            excess_kurtosis=excess_kurtosis,
+            powerline_hz=powerline_hz,
+            powerline_amplitude=powerline_amplitude,
+            powerline_harmonic_ratios=init["powerline_harmonic_ratios"],
+            peak_hz=peak_hz,
+            analog_hpf_hz=analog_hpf_hz,
+            rng=np.random.default_rng(base_rng.integers(0, 2**31 - 1)),
+        )
+        _, trial_psd = sig.welch(
+            trial_noise, fs=fs_hz, nperseg=nperseg, noverlap=noverlap, average="median"
+        )
+        log_trial = np.log10(np.maximum(trial_psd, 1e-30))
+        # Compare against the un-notched real PSD so the powerline lines
+        # contribute to the fit.
+        loss = float(np.mean(np.abs(log_trial[band_mask] - log_real_raw[band_mask])))
+        return loss
+
+    sampler = optuna.samplers.TPESampler(seed=seed)
+    study = optuna.create_study(direction="minimize", sampler=sampler)
+
+    # Seed the search with the closed-form result so the first trial
+    # is already a good baseline.
+    study.enqueue_trial(
+        {
+            "noise_floor_uv": float(init["noise_floor_uv"]),
+            "spectral_slope": float(init["spectral_slope"]),
+            "peak_hz": float(init["peak_hz"]),
+            "excess_kurtosis": float(init["excess_kurtosis"]),
+            "powerline_amplitude": float(init["powerline_amplitude"]),
+            "analog_hpf_hz": float(init["analog_hpf_hz"]),
+        }
+    )
+    study.optimize(_objective, n_trials=n_trials, show_progress_bar=show_progress_bar)
+
+    best = study.best_params
+    tuned = {
+        "noise_floor_uv": float(best["noise_floor_uv"]),
+        "spectral_slope": float(best["spectral_slope"]),
+        "peak_hz": float(best["peak_hz"]),
+        "excess_kurtosis": float(best["excess_kurtosis"]),
+        "powerline_hz": float(powerline_hz),
+        "powerline_amplitude": float(best["powerline_amplitude"]),
+        "powerline_harmonic_ratios": list(init["powerline_harmonic_ratios"]),
+        "analog_hpf_hz": float(best["analog_hpf_hz"]),
+        "_optuna_loss": float(study.best_value),
+    }
+    return tuned

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -222,3 +222,346 @@ def test_default_synaptic_params_rescale_nonnative_delay():
     assert netcon.delay == 1000.0  # 1 s -> 1000 ms; buggy code stored 1.0
     assert netcon.weight[0] == 0.6  # DEFAULT_SYNAPTIC_WEIGHT magnitude (uS)
     assert netcon.threshold == -10.0  # DEFAULT_SPIKE_THRESHOLD magnitude (mV)
+
+
+def test_intramuscular_add_noise_realistic_preserves_per_channel_snr():
+    """``noise_type='realistic'`` honours MyoGen's per-channel SNR contract.
+
+    The colored-noise pipeline is calibrated against real fine-wire iEMG
+    (1/f base + mid-band emphasis + heavy tails + powerline). The
+    integration must still hit ``snr__dB`` independently per electrode
+    so channels with different amplitudes get appropriately scaled
+    noise, matching the legacy gaussian path.
+    """
+    from myogen import set_random_seed
+    from myogen.simulator.core.emg.intramuscular.intramuscular_emg import (
+        IntramuscularEMG,
+    )
+
+    set_random_seed(0)
+
+    fs_hz = 4096.0
+    n_samples = int(8.0 * fs_hz)  # 8 s — long enough for the RMS to settle
+    rng = np.random.default_rng(0)
+
+    # Two channels with deliberately different amplitudes (5x apart).
+    base = rng.standard_normal(n_samples)
+    emg_array = np.stack([base, 5.0 * base], axis=1)
+
+    block = Block()
+    segment = Segment(name="Pool_0")
+    segment.analogsignals.append(
+        AnalogSignal(
+            emg_array * pq.dimensionless,
+            t_start=0 * pq.s,
+            sampling_rate=fs_hz * pq.Hz,
+        )
+    )
+    block.segments.append(segment)
+
+    simulator = object.__new__(IntramuscularEMG)
+    simulator._intramuscular_emg__Block = block
+    simulator._noisy_intramuscular_emg__Block = None
+    simulator._sampling_frequency__Hz = fs_hz
+
+    snr_db = 20.0
+    noisy_block = IntramuscularEMG.add_noise(
+        simulator,
+        snr__dB=snr_db,
+        noise_type="realistic",
+        # Disable powerline so the residual is pure colored noise — the
+        # per-channel SNR check would otherwise count the 50 Hz line as
+        # additional "noise" beyond the budgeted RMS.
+        powerline_amplitude=0.0,
+    )
+
+    noisy = noisy_block.segments[0].analogsignals[0].magnitude
+    assert noisy.shape == emg_array.shape
+
+    for ch in range(emg_array.shape[1]):
+        signal_rms = float(np.sqrt(np.mean(emg_array[:, ch] ** 2)))
+        noise_rms = float(np.sqrt(np.mean((noisy[:, ch] - emg_array[:, ch]) ** 2)))
+        observed_snr_db = 20.0 * np.log10(signal_rms / noise_rms)
+        # The colored-noise pipeline normalises to the budgeted RMS via
+        # signal stats, so the realised per-channel SNR should sit within
+        # ±1.5 dB of the target across an 8 s window.
+        assert abs(observed_snr_db - snr_db) < 1.5, (
+            f"channel {ch}: SNR {observed_snr_db:.2f} dB != {snr_db} ± 1.5 dB"
+        )
+
+
+def test_intramuscular_add_noise_realistic_injects_powerline_peak():
+    """An exaggerated powerline amplitude must show as a 50 Hz peak."""
+    from myogen import set_random_seed
+    from myogen.simulator.core.emg.intramuscular.intramuscular_emg import (
+        IntramuscularEMG,
+    )
+
+    set_random_seed(0)
+
+    fs_hz = 2048.0
+    n_samples = int(4.0 * fs_hz)
+    rng = np.random.default_rng(1)
+
+    emg_array = (rng.standard_normal((n_samples, 1)) * 0.01).astype(float)
+
+    block = Block()
+    segment = Segment(name="Pool_0")
+    segment.analogsignals.append(
+        AnalogSignal(
+            emg_array * pq.dimensionless,
+            t_start=0 * pq.s,
+            sampling_rate=fs_hz * pq.Hz,
+        )
+    )
+    block.segments.append(segment)
+
+    simulator = object.__new__(IntramuscularEMG)
+    simulator._intramuscular_emg__Block = block
+    simulator._noisy_intramuscular_emg__Block = None
+    simulator._sampling_frequency__Hz = fs_hz
+
+    noisy_block = IntramuscularEMG.add_noise(
+        simulator,
+        snr__dB=0.0,  # noise RMS == signal RMS
+        noise_type="realistic",
+        powerline_hz=50.0,
+        powerline_amplitude=0.8,  # exaggerated
+        powerline_harmonic_ratios=[1.0, 0.0, 0.0, 0.0, 0.0],  # fundamental only
+    )
+
+    residual = (
+        noisy_block.segments[0].analogsignals[0].magnitude[:, 0]
+        - emg_array[:, 0]
+    )
+    freqs = np.fft.rfftfreq(len(residual), d=1.0 / fs_hz)
+    psd = np.abs(np.fft.rfft(residual)) ** 2
+
+    bin_50 = int(np.argmin(np.abs(freqs - 50.0)))
+    # Pick a quiet reference band away from 50 Hz that the colored noise
+    # actually covers, so we are measuring the powerline spike, not the
+    # spectral slope.
+    ref_lo = int(np.argmin(np.abs(freqs - 200.0)))
+    ref_hi = int(np.argmin(np.abs(freqs - 400.0)))
+    ref_psd = float(np.mean(psd[ref_lo : ref_hi + 1]))
+    peak_psd = float(np.mean(psd[max(0, bin_50 - 1) : bin_50 + 2]))
+
+    assert peak_psd > 10.0 * ref_psd, (
+        f"50 Hz peak ({peak_psd:.2e}) not >10x ref band ({ref_psd:.2e})"
+    )
+
+
+def test_baseline_drift_off_by_default_preserves_noise_rms():
+    """Default ``baseline_drift_rms_uv=0`` must leave generated noise unchanged.
+
+    Regression guard for the SNR contract — historical callers don't pass
+    the new kwargs and expect ``noise_rms`` to be the only thing that
+    controls the output RMS.
+    """
+    from myogen.utils import generate_realistic_noise
+
+    fs_hz = 10240.0
+    n = int(8.0 * fs_hz)
+
+    # Explicit seeded rng so the two calls are bit-identical when drift
+    # is at its default (no extra rng draws).
+    no_drift = generate_realistic_noise(
+        n, fs_hz, noise_rms=5.0, rng=np.random.default_rng(0)
+    )
+    default_drift = generate_realistic_noise(
+        n, fs_hz, noise_rms=5.0, baseline_drift_rms_uv=0.0,
+        rng=np.random.default_rng(0),
+    )
+    np.testing.assert_array_equal(no_drift, default_drift)
+    rms = float(np.sqrt(np.mean(no_drift ** 2)))
+    assert abs(rms - 5.0) < 0.05, f"broadband RMS {rms:.3f} != 5.0 ± 0.05"
+
+
+def test_baseline_drift_amplitude_and_band():
+    """Baseline drift hits the requested RMS and stays in the LF band.
+
+    The drift is additive on top of broadband, so total noise RMS
+    should match ``sqrt(noise_rms**2 + drift_rms**2)``. The band is
+    now a hard band-limit at ``baseline_drift_high_hz``, so at least
+    90% of the drift power must land below that cutoff.
+    """
+    from scipy import signal as sig
+
+    from myogen.utils import generate_realistic_noise
+
+    fs_hz = 10240.0
+    n = int(16.0 * fs_hz)
+    noise_rms = 5.0
+    drift_rms = 2.0
+    high_hz = 1.0
+
+    # Same rng seed for both calls so the broadband draws match, then
+    # ``with_drift - no_drift`` isolates the drift component exactly.
+    no_drift = generate_realistic_noise(
+        n, fs_hz, noise_rms=noise_rms, rng=np.random.default_rng(0)
+    )
+    with_drift = generate_realistic_noise(
+        n, fs_hz, noise_rms=noise_rms,
+        baseline_drift_rms_uv=drift_rms,
+        baseline_drift_alpha=1.75,
+        baseline_drift_high_hz=high_hz,
+        rng=np.random.default_rng(0),
+    )
+
+    expected_total = float(np.sqrt(noise_rms ** 2 + drift_rms ** 2))
+    observed_total = float(np.sqrt(np.mean(with_drift ** 2)))
+    assert abs(observed_total - expected_total) < 0.15, (
+        f"total RMS {observed_total:.3f} != expected {expected_total:.3f} ± 0.15"
+    )
+
+    drift_only = with_drift - no_drift
+    drift_only_rms = float(np.sqrt(np.mean(drift_only ** 2)))
+    assert abs(drift_only_rms - drift_rms) < 0.15, (
+        f"drift-only RMS {drift_only_rms:.3f} != requested {drift_rms:.3f}"
+    )
+
+    # >= 90% of drift power must lie below the hard band edge.
+    sos_lp = sig.butter(4, high_hz, fs=fs_hz, btype="low", output="sos")
+    drift_in_band = sig.sosfiltfilt(sos_lp, drift_only)
+    drift_in_band_rms = float(np.sqrt(np.mean(drift_in_band ** 2)))
+    assert drift_in_band_rms >= 0.9 * drift_only_rms, (
+        f"in-band (<{high_hz} Hz) drift RMS {drift_in_band_rms:.3f} is only "
+        f"{100 * drift_in_band_rms / drift_only_rms:.0f}% of total drift RMS "
+        f"{drift_only_rms:.3f} — drift is leaking above the band limit"
+    )
+
+
+def test_baseline_drift_slope_matches_alpha():
+    """Fitted log-log PSD slope over the drift band matches -alpha.
+
+    The sub-1-Hz band has only ~8 Welch bins at 0.125 Hz resolution,
+    so the slope estimate has significant variance. We use a longer
+    signal (64 s) to get more Welch segments and loosen the tolerance
+    accordingly — this is a sanity check on the spectral SHAPE, not a
+    precision unit test of the fitter.
+    """
+    from scipy import signal as sig
+
+    from myogen.utils import generate_realistic_noise
+
+    fs_hz = 10240.0
+    n = int(64.0 * fs_hz)
+    alpha_in = 2.0
+    high_hz = 1.0
+
+    drift = generate_realistic_noise(
+        n, fs_hz, noise_rms=0.0,
+        powerline_hz=0.0,
+        baseline_drift_rms_uv=5.0,
+        baseline_drift_alpha=alpha_in,
+        baseline_drift_high_hz=high_hz,
+        rng=np.random.default_rng(0),
+    )
+
+    nperseg = min(len(drift), int(8 * fs_hz))
+    freqs, psd = sig.welch(drift, fs=fs_hz, nperseg=nperseg, average="median")
+    fit_mask = (freqs >= freqs[1]) & (freqs <= high_hz) & (psd > 0)
+    assert np.count_nonzero(fit_mask) >= 3, "too few PSD bins for slope fit"
+    slope, _ = np.polyfit(np.log10(freqs[fit_mask]), np.log10(psd[fit_mask]), 1)
+    fitted_alpha = -slope
+    assert abs(fitted_alpha - alpha_in) < 1.0, (
+        f"fitted alpha {fitted_alpha:.2f} != target {alpha_in:.2f} ± 1.0"
+    )
+
+
+def test_calibrate_baseline_drift_profile_round_trip():
+    """Calibration on a known-drift trace recovers RMS and α to within tolerance.
+
+    The generation and calibration bands must agree. With
+    ``low_hz=None`` the generator can place power at frequencies
+    below what a typical Welch nperseg can resolve, which would bias
+    the recovered RMS downward — that is a real limitation of any
+    PSD-based fitter on short traces. To exercise the round-trip
+    fairly we pin both the generation and the calibration to the same
+    band [0.1, 1.0] Hz, well above the Welch resolution.
+    """
+    from myogen.utils import (
+        calibrate_baseline_drift_profile,
+        generate_realistic_noise,
+    )
+
+    fs_hz = 10240.0
+    n = int(64.0 * fs_hz)
+    target_rms = 3.0
+    target_alpha = 1.75
+    low_hz = 0.1
+    high_hz = 1.0
+
+    drift = generate_realistic_noise(
+        n, fs_hz, noise_rms=0.0,
+        powerline_hz=0.0,
+        baseline_drift_rms_uv=target_rms,
+        baseline_drift_alpha=target_alpha,
+        baseline_drift_low_hz=low_hz,
+        baseline_drift_high_hz=high_hz,
+        rng=np.random.default_rng(0),
+    )
+
+    profile = calibrate_baseline_drift_profile(
+        drift, fs_hz, band=(low_hz, high_hz)
+    )
+
+    assert {
+        "baseline_drift_rms_uv",
+        "baseline_drift_alpha",
+        "baseline_drift_low_hz",
+        "baseline_drift_high_hz",
+    } <= set(profile.keys())
+    assert abs(profile["baseline_drift_rms_uv"] - target_rms) < 0.30 * target_rms, (
+        f"recovered RMS {profile['baseline_drift_rms_uv']:.3f} != "
+        f"target {target_rms:.3f} ± 30%"
+    )
+    assert abs(profile["baseline_drift_alpha"] - target_alpha) < 1.0, (
+        f"recovered α {profile['baseline_drift_alpha']:.2f} != "
+        f"target {target_alpha:.2f} ± 1.0"
+    )
+    assert profile["baseline_drift_high_hz"] == high_hz
+
+
+def test_baseline_drift_rejects_invalid_params():
+    """Negative/zero/out-of-range parameter values must raise."""
+    import pytest
+
+    from myogen.utils import generate_realistic_noise
+
+    fs_hz = 10240.0
+    n = 4096
+
+    with pytest.raises(ValueError, match="baseline_drift_rms_uv"):
+        generate_realistic_noise(
+            n, fs_hz, noise_rms=5.0, baseline_drift_rms_uv=-1.0
+        )
+    with pytest.raises(ValueError, match="baseline_drift_alpha"):
+        generate_realistic_noise(
+            n, fs_hz, noise_rms=5.0,
+            baseline_drift_rms_uv=1.0, baseline_drift_alpha=0.0,
+        )
+    with pytest.raises(ValueError, match="baseline_drift_high_hz"):
+        generate_realistic_noise(
+            n, fs_hz, noise_rms=5.0,
+            baseline_drift_rms_uv=1.0, baseline_drift_high_hz=0.0,
+        )
+    with pytest.raises(ValueError, match="baseline_drift_high_hz"):
+        # high_hz >= Nyquist
+        generate_realistic_noise(
+            n, fs_hz, noise_rms=5.0,
+            baseline_drift_rms_uv=1.0, baseline_drift_high_hz=fs_hz / 2.0,
+        )
+    with pytest.raises(ValueError, match="baseline_drift_low_hz"):
+        generate_realistic_noise(
+            n, fs_hz, noise_rms=5.0,
+            baseline_drift_rms_uv=1.0, baseline_drift_low_hz=0.0,
+        )
+    with pytest.raises(ValueError, match="baseline_drift_low_hz"):
+        # low_hz >= high_hz
+        generate_realistic_noise(
+            n, fs_hz, noise_rms=5.0,
+            baseline_drift_rms_uv=1.0,
+            baseline_drift_low_hz=2.0,
+            baseline_drift_high_hz=1.0,
+        )


### PR DESCRIPTION
Adds a realistic, device-calibratable intramuscular-EMG noise model and supporting examples.

## Changes
- **feat(noise):** `myogen.utils.emg_noise` — generate/add spectrally-colored iEMG noise (broadband floor, analog high-pass, powerline, baseline drift), rest-period calibration (closed-form + Optuna refinement), and baseline-drift profiling. Wires `noise_type="realistic"` into `IntramuscularEMG.add_noise` alongside the legacy gaussian path; exports the API; adds regression tests (per-channel SNR, powerline peak, baseline drift).
- **docs(examples):** `14_calibrate_noise_from_real` (fit the model to a real recording; `MYOGEN_IEMG_MAT` override + synthetic fallback) and `15_noise_parameter_sweep` (per-knob spectral sweeps). Example 09 bumped to ~34 MUs for a realistic composite iEMG base.
- **ci:** drop the retired macOS Intel (`macos-13`) wheel build; wheels on `ubuntu-latest` + `macos-latest` (Apple Silicon).
- **chore:** gitignore `.DS_Store` and local `notes/`.

Tests pass; `ruff check` clean on the noise files.